### PR TITLE
Fix dotnet build for fedora kojibuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 add_custom_command(
     TARGET credentials-fetcherd
     PRE_LINK
-    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && dotnet publish -c Release && cp bin/Release/net6.0/linux-x64/publish/utf16_decode $CURR_DIR/credentials_fetcher_utf16_private.exe"
+    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && dotnet build && dotnet publish -c Release && cp bin/Release/net6.0/linux-x64/publish/utf16_decode $CURR_DIR/credentials_fetcher_utf16_private.exe"
     VERBATIM)
 
 target_include_directories(credentials-fetcherd PUBLIC common)

--- a/auth/kerberos/src/utf16_decode/nuget.config
+++ b/auth/kerberos/src/utf16_decode/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
* Avoid dotnet restore for koji build since koji does not connect to internet

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
