### PR TITLE
Use dotnet csc compiler for Fedora build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 add_custom_command(
     TARGET credentials-fetcherd
     PRE_LINK
-    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && ./build-using-csc.sh Program.cs && cp Program.exe $CURR_DIR/credentials_fetcher_utf16_private.exe && cp Program.runtimeconfig.json credentials_fetcher_utf16_private.runtimeconfig.json"
+    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && ./build-using-csc.sh Program.cs && cp Program.exe $CURR_DIR/credentials_fetcher_utf16_private.exe && cp Program.runtimeconfig.json $CURR_DIR/credentials_fetcher_utf16_private.runtimeconfig.json"
     VERBATIM)
 
 target_include_directories(credentials-fetcherd PUBLIC common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 add_custom_command(
     TARGET credentials-fetcherd
     PRE_LINK
-    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && ./build-using-csc.sh Program.cs && cp Program.exe $CURR_DIR/credentials_fetcher_utf16_private.exe"
+    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && ./build-using-csc.sh Program.cs && cp Program.exe $CURR_DIR/credentials_fetcher_utf16_private.exe && cp Program.runtimeconfig.json credentials_fetcher_utf16_private.runtimeconfig.json"
     VERBATIM)
 
 target_include_directories(credentials-fetcherd PUBLIC common)
@@ -120,6 +120,9 @@ install(FILES ${CMAKE_BINARY_DIR}/credentials-fetcherd
 install(FILES ${CMAKE_SOURCE_DIR}/scripts/systemd/credentials-fetcher.service
         DESTINATION "/usr/lib/systemd/system/")
 install(FILES ${CMAKE_BINARY_DIR}/credentials_fetcher_utf16_private.exe
+        DESTINATION "/usr/sbin/"
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+install(FILES ${CMAKE_BINARY_DIR}/credentials_fetcher_utf16_private.runtimeconfig.json
         DESTINATION "/usr/sbin/"
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 add_custom_command(
     TARGET credentials-fetcherd
     PRE_LINK
-    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && dotnet build && dotnet publish -c Release && cp bin/Release/net6.0/linux-x64/publish/utf16_decode $CURR_DIR/credentials_fetcher_utf16_private.exe"
+    COMMAND bash -c  "CURR_DIR=$PWD && echo $CURR_DIR && cd ${CMAKE_CURRENT_SOURCE_DIR}/auth/kerberos/src/utf16_decode && ./build-using-csc.sh Program.cs && cp Program.exe $CURR_DIR/credentials_fetcher_utf16_private.exe"
     VERBATIM)
 
 target_include_directories(credentials-fetcherd PUBLIC common)

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -522,7 +522,7 @@ std::pair<int, std::string> get_gmsa_krb_ticket( std::string domain_name,
     std::string default_principal = "'" + gmsa_account_name + "$'" + "@" + domain_name;
 
     /* Pipe password to the utf16 decoder and kinit */
-    std::string kinit_cmd = std::string( install_path_for_decode_exe ) +
+    std::string kinit_cmd = std::string("dotnet ") + std::string( install_path_for_decode_exe ) +
                             std::string( " | kinit " ) + std::string( " -c " ) + krb_cc_name +
                             " -V " + default_principal;
     std::cout << kinit_cmd << std::endl;

--- a/auth/kerberos/src/utf16_decode/Program.runtimeconfig.json
+++ b/auth/kerberos/src/utf16_decode/Program.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "6.0.0"
+    }
+  }
+}

--- a/auth/kerberos/src/utf16_decode/build-using-csc.sh
+++ b/auth/kerberos/src/utf16_decode/build-using-csc.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Thanks to https://github.com/dotnet/sdk/issues/8742#issuecomment-890559867
+
+DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_CLI_TELEMETRY_OPTOUT
+
+sdkver=$(LC_ALL=C dotnet --version)
+fwkver=$(LC_ALL=C dotnet --list-runtimes | \
+    LC_ALL=C sed --posix -n '/^Microsoft.NETCore.App \([^ ]*\) .*$/{s//\1/p;q;}')
+
+# dotnet-sdk-5.0 installed via .deb package
+dotnethome=/usr/lib64/dotnet
+dotnetlib=$dotnethome/shared/Microsoft.NETCore.App/$fwkver
+dotnet_cscdll=$dotnethome/sdk/$sdkver/Roslyn/bincore/csc.dll
+dotnet_csclib='-r:netstandard.dll -r:Microsoft.CSharp.dll -r:System.dll'
+for x in "$dotnetlib"/System.*.dll; do
+	dotnet_csclib="$dotnet_csclib -r:${x##*/}"
+done
+# add if needed
+#dotnet_csclib="$dotnet_csclib -r:Microsoft.Win32.Primitives.dll"
+
+exec dotnet "$dotnet_cscdll" "-lib:$dotnetlib" $dotnet_csclib "$@"
+
+#!/bin/sh
+
+DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_CLI_TELEMETRY_OPTOUT
+
+sdkver=$(LC_ALL=C dotnet --version)
+fwkver=$(LC_ALL=C dotnet --list-runtimes | \
+    LC_ALL=C sed --posix -n '/^Microsoft.NETCore.App \([^ ]*\) .*$/{s//\1/p;q;}')
+
+exename=$1
+case $exename in
+(*.exe|*.EXE) ;;
+(*)
+	echo >&2 "E: $exename is not a .exe file"
+	exit 1
+	;;
+esac
+
+jsonname=${exename%.*}.runtimeconfig.json
+printf '%s"%s"%s\n' \
+    '{"runtimeOptions":{"framework":{"name":"Microsoft.NETCore.App","version":' \
+    "$fwkver" '}}}' >"$jsonname"

--- a/auth/kerberos/src/utf16_decode/nuget.config
+++ b/auth/kerberos/src/utf16_decode/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-  </packageSources>
-</configuration>

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -20,7 +20,7 @@ Requires: bind-utils openldap openldap-clients
 #Requres: grpc-cli
 
 # No one likes you i686
-ExcludeArch:    i686 armv7hl
+ExcludeArch:    i686 armv7hl ppc64le
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/
 

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -58,6 +58,7 @@ ctest3
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 %doc CONTRIBUTING.md NOTICE README.md
 %attr(0700, -, -) %{_sbindir}/credentials_fetcher_utf16_private.exe
+%attr(0700, -, -) %{_sbindir}/credentials_fetcher_utf16_private.runtimeconfig.json
 
 %changelog
 * Wed Oct 12 2022 Sai Kiran Akula <saakla@amazon.com> - 1.0.0


### PR DESCRIPTION
The csc compiler does not restore from the internet. The Fedora koji build needs this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
