### PR TITLE
Add Domainless gMSA

### DIFF
--- a/common/daemon.h
+++ b/common/daemon.h
@@ -79,6 +79,7 @@ namespace creds_fetcher
         std::string logging_dir;
         std::string domain_name;
         std::string gmsa_account_name;
+        std::string aws_sm_secret_name;
         CF_logger cf_logger;
         bool run_diagnostic = false;
         std::string aws_sm_secret_name; /* TBD:: Extend to other secret stores */

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -16,7 +17,6 @@
 #include <thread>
 #include <unistd.h>
 #include <vector>
-#include "config.h"
 
 #ifndef _daemon_h_
 #define _daemon_h_
@@ -81,6 +81,7 @@ namespace creds_fetcher
         std::string gmsa_account_name;
         CF_logger cf_logger;
         bool run_diagnostic = false;
+        std::string aws_sm_secret_name; /* TBD:: Extend to other secret stores */
         // run ticket renewal every 10 minutes
         uint64_t krb_ticket_handle_interval = 10;
         volatile sig_atomic_t got_systemd_shutdown_signal;
@@ -111,6 +112,8 @@ namespace creds_fetcher
 int generate_host_machine_krb_ticket( const char* krb_ccname = "" );
 
 int get_machine_krb_ticket( std::string domain_name, creds_fetcher::CF_logger& cf_logger );
+int get_user_krb_ticket( std::string domain_name, std::string aws_sm_secret_name,
+                         creds_fetcher::CF_logger& cf_logger );
 
 std::pair<int, std::string> get_gmsa_krb_ticket( std::string domain_name,
                                                  const std::string& gmsa_account_name,
@@ -149,7 +152,8 @@ int parse_config_file( creds_fetcher::Daemon& cf_daemon );
  * Methods in api module
  */
 int RunGrpcServer( std::string unix_socket_dir, std::string krb_file_path,
-                   creds_fetcher::CF_logger& cf_logger, volatile sig_atomic_t* shutdown_signal );
+                   creds_fetcher::CF_logger& cf_logger, volatile sig_atomic_t* shutdown_signal,
+                   std::string aws_sm_secret_name );
 
 int parse_cred_spec( std::string credspec_data, creds_fetcher::krb_ticket_info* krb_ticket_info );
 
@@ -163,7 +167,7 @@ int krb_ticket_renew_handler( creds_fetcher::Daemon cf_daemon );
 /**
  * Methods in metadata module
  */
-bool contains_invalid_characters(const std::string & path);
+bool contains_invalid_characters( const std::string& path );
 std::list<creds_fetcher::krb_ticket_info*> read_meta_data_json( std::string file_path );
 
 int write_meta_data_json( std::list<creds_fetcher::krb_ticket_info*> krb_ticket_info_list,

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -79,7 +79,6 @@ namespace creds_fetcher
         std::string logging_dir;
         std::string domain_name;
         std::string gmsa_account_name;
-        std::string aws_sm_secret_name;
         CF_logger cf_logger;
         bool run_diagnostic = false;
         std::string aws_sm_secret_name; /* TBD:: Extend to other secret stores */

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -8,6 +8,7 @@
  * @param cf_daemon - credentials fetcher parent object
  * @return status - 0 if successful
  */
+
 int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemon )
 {
     try
@@ -17,8 +18,11 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
         /* Declare the supported options */
         po::options_description desc( "Allowed options" );
         desc.add_options()( "help", "produce help message" ) /* TBD: Add help message description */
-                ("self_test",  "Run tests such as utf16 decode" )
-                ("verbosity", po::value<int>(), "set verbosity level" );
+            ( "self_test", "Run tests such as utf16 decode" )( "verbosity", po::value<int>(),
+                                                               "set verbosity level" )(
+                "aws_sm_secret_name", po::value<std::string>(), // TBD:: Extend to other stores
+                "Name of secret containing username/password in AWS Secrets Manager (in same "
+                "region)" );
 
         /**
          * Calls to store, parse_command_line and notify functions
@@ -43,6 +47,14 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
         {
             std::cout << "run diagnostic set" << std::endl;
             cf_daemon.run_diagnostic = true;
+        }
+
+        if ( vm.count( "aws_sm_secret_name" ) ) // TBD:: Extend to other stores
+        {
+            cf_daemon.aws_sm_secret_name = vm["aws_sm_secret_name"].as<std::string>();
+            std::cout
+                << "Option selected for domainless operation, AWS secrets manager secret-name = "
+                << cf_daemon.aws_sm_secret_name << std::endl;
         }
     }
     catch ( const boost::program_options::error& ex )

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -11,6 +11,9 @@
 
 int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemon )
 {
+    const char* ecs_config_file_name = "/etc/ecs/ecs.config"; // TBD:: Add commandline if needed
+    std::string domainless_gmsa_field( "CREDENTIALS_FETCHER_SECRET_NAME_FOR_DOMAINLESS_GMSA" );
+
     try
     {
         namespace po = boost::program_options;
@@ -55,6 +58,24 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
             std::cout
                 << "Option selected for domainless operation, AWS secrets manager secret-name = "
                 << cf_daemon.aws_sm_secret_name << std::endl;
+        }
+
+        std::ifstream config_file( ecs_config_file_name );
+        std::string line;
+        std::vector<std::string> results;
+
+        while ( std::getline( config_file, line ) )
+        {
+            // TBD: Error handling for incorrectly formatted /etc/ecs/ecs.config
+            boost::split( results, line, []( char c ) { return c == '='; } );
+            std::string key = results[0];
+            std::string value = results[1];
+            if ( domainless_gmsa_field.compare( key ) == 0 )
+            {
+                value.erase( std::remove( value.begin(), value.end(), '"' ), value.end() );
+                std::cout << "Using " << value << " for domainless gMSA" << std::endl;
+                cf_daemon.aws_sm_secret_name = value;
+            }
         }
     }
     catch ( const boost::program_options::error& ex )

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -18,7 +18,7 @@ BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-de
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
 BuildRequires:  systemd-rpm-macros dotnet grpc-plugins
 
-Requires: bind-utils openldap openldap-clients
+Requires: bind-utils openldap openldap-clients awscli
 
 # No one likes you i686
 ExcludeArch:    i686 armv7hl ppc64le
@@ -62,6 +62,8 @@ ctest3
 %attr(0700, -, -) %{_sbindir}/credentials_fetcher_utf16_private.runtimeconfig.json
 
 %changelog
+* Mon Oct 24 2022 Samiullah Mohammed <samiull@amazon.com> - 1.0.0
+- Add domainless gmsa
 * Wed Oct 12 2022 Sai Kiran Akula <saakla@amazon.com> - 1.0.0
 - Create 1.0 release
 * Mon Sep 19 2022 Tom Callaway <spotaws@amazon.com> - 0.0.94-2


### PR DESCRIPTION
With this feature, the host does not have to be domain-joined.

The feature is outlined at https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts#use-case-for-creating-gmsa-account-for-non-domain-joined-container-hosts

Testing

    [root@ip-10-0-0-67 build]# ./credentials-fetcherd  --aws_sm_secret_name  aws/directoryservices/d-xxxxxxx/gmsa
    [root@ip-10-0-0-67 build]# ./api/tests/gmsa_test_client

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
