### PR TITLE
Replace deprecated boost::filesystem::ofstream with std::ofstream

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/filesystem.hpp>
 #include <credentialsfetcher.grpc.pb.h>
+#include <fstream>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -180,7 +181,7 @@ class CredentialsFetcherImpl final
 
                         if ( !boost::filesystem::exists( krb_ccname_str ) )
                         {
-                            boost::filesystem::ofstream file( krb_ccname_str );
+                            std::ofstream file( krb_ccname_str );
                             file.close();
 
                             krb_ticket->krb_file_path = krb_ccname_str;


### PR DESCRIPTION
As reported in [Fedora bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2172636), with boost 1.81.0, the boost::filesystem::ofstream type has been deprecated. Switching to the std::ofstream type is the appropriate change, and we need to #include <fstream> as a result.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
