### PR TITLE
fix domain name length for host machine

### DIFF
--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -8,8 +8,8 @@
 // renew the ticket 1 hrs before the expiration
 #define RENEW_TICKET_HOURS 1
 #define SECONDS_IN_HOUR 3600
-// Windows doesn't permit computer names that exceed 15 characters, and you can't specify a DNS host name that differs from the NetBIOS host name.
-//https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
+// Active Directory uses NetBIOS computer names that do not exceed 15 characters.
+// https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
 #define HOST_NAME_LENGTH_LIMIT 15
 
 static const std::string install_path_for_decode_exe =
@@ -112,6 +112,9 @@ static std::pair<int, std::string> get_machine_principal( std::string domain_nam
 
     // truncate the hostname to the host name size limit defined by microsoft
     if(host_name.length() > HOST_NAME_LENGTH_LIMIT){
+        cf_logger.logger( LOG_ERR, "WARNING: %s:%d hostname exceeds 15 characters, "
+             "this can cause problems in getting kerberos tickets, please reduce hostname length",
+             __func__, __LINE__ );
         host_name = host_name.substr(0,HOST_NAME_LENGTH_LIMIT);
     }
 

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -8,6 +8,9 @@
 // renew the ticket 1 hrs before the expiration
 #define RENEW_TICKET_HOURS 1
 #define SECONDS_IN_HOUR 3600
+// Windows doesn't permit computer names that exceed 15 characters, and you can't specify a DNS host name that differs from the NetBIOS host name.
+//https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
+#define HOST_NAME_LENGTH_LIMIT 15
 
 static const std::string install_path_for_decode_exe =
     "/usr/sbin/credentials_fetcher_utf16_private.exe";
@@ -105,11 +108,18 @@ static std::pair<int, std::string> get_machine_principal( std::string domain_nam
         return result;
     }
 
+    std::string host_name = hostname_result.second;
+
+    // truncate the hostname to the host name size limit defined by microsoft
+    if(host_name.length() > HOST_NAME_LENGTH_LIMIT){
+        host_name = host_name.substr(0,HOST_NAME_LENGTH_LIMIT);
+    }
+
     /**
      * Machine principal is of the format EC2AMAZ-Q5VJZQ$@CONTOSO.COM'
      */
     result.first = 0;
-    result.second = hostname_result.second + "$@" + realm_name_result.second;
+    result.second = host_name + "$@" + realm_name_result.second;
 
     return result;
 }

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -112,7 +112,7 @@ static std::pair<int, std::string> get_machine_principal( std::string domain_nam
 
     // truncate the hostname to the host name size limit defined by microsoft
     if(host_name.length() > HOST_NAME_LENGTH_LIMIT){
-        cf_logger.logger( LOG_ERR, "WARNING: %s:%d hostname exceeds 15 characters, "
+        cf_logger.logger( LOG_ERR, "WARNING: %s:%d hostname exceeds 15 characters,
              "this can cause problems in getting kerberos tickets, please reduce hostname length",
              __func__, __LINE__ );
         host_name = host_name.substr(0,HOST_NAME_LENGTH_LIMIT);

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -16,9 +16,9 @@ Source0:        https://github.com/aws/credentials-fetcher/archive/refs/tags/%{v
 
 BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel boost-devel 
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
-BuildRequires:  systemd-rpm-macros dotnet grpc-plugins
+BuildRequires:  systemd-rpm-macros dotnet-sdk-6.0 grpc-plugins
 
-Requires: bind-utils openldap openldap-clients awscli
+Requires: bind-utils openldap openldap-clients awscli dotnet-runtime-6.0
 
 # No one likes you i686
 ExcludeArch:    i686 armv7hl ppc64le


### PR DESCRIPTION
*Issue #, if available:*
Microsoft doesn't allow computer names to be more than 15 characters

*Description of changes:*
AD truncates hostname when domain-joined linux instances. We are following the same limit for truncating hostnames on credentials-fetcher daemon by helping users not needing to rename host-names


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
