### PR TITLE
Invoke kinit as API instead of command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
 file(STRINGS /etc/os-release DISTRO REGEX "^NAME=")
 string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" DISTRO "${DISTRO}")
 
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 set(config)
 add_subdirectory(config)
 set(api)
@@ -49,7 +51,7 @@ if (NOT CF_TEST_GMSA_ACCOUNT)
 endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/config/config.h.in
-	${CMAKE_BINARY_DIR}/config.h @ONLY)
+    ${CMAKE_BINARY_DIR}/config.h @ONLY)
 
 if(DISTRO MATCHES "^(Amazon Linux)$")
 file(WRITE scripts/systemd/credentials-fetcher.service
@@ -87,7 +89,7 @@ else()
             )
 endif()
 
-set(sources ${auth} ${daemon} ${config} ${renewal})
+set(sources ${daemon} ${config} ${renewal})
 
 add_executable(credentials-fetcherd ${sources})
 
@@ -109,7 +111,7 @@ target_include_directories(credentials-fetcherd
         common
         ${GLIB_INCLUDE_DIR}
         ${GLIB_CONFIG_DIR}
-	    ${CMAKE_CURRENT_BINARY_DIR})
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 find_program(DOTNET dotnet ~/.dotnet /usr/bin)
 if (NOT DOTNET)
@@ -125,8 +127,10 @@ add_custom_command(
 target_include_directories(credentials-fetcherd PUBLIC common)
 
 target_link_libraries(credentials-fetcherd
-        PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private boost_filesystem boost_system crypto)
-
+        PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private
+        boost_filesystem boost_system crypto
+        kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
+        com_err krb5support resolv)
 
 target_link_libraries(credentials-fetcherd
             PUBLIC

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -29,23 +29,26 @@ list(APPEND SRC_FILES ${credentialsfetcher_grpc_sources})
 list(APPEND SRC_FILES ${credentialsfetcher_grpc_headers})
 
 add_library(cf_gmsa_service_private OBJECT
-	${SRC_FILES}
-	${credentialsfetcher_proto_sources}
-	${credentialsfetcher_proto_headers}
-	${credentialsfetcher_grpc_sources}
-	${credentialsfetcher_grpc_headers}
-	${CMAKE_CURRENT_SOURCE_DIR}/../auth/kerberos/src/krb.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../metadata/src/metadata.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../metadata/tests/metadata_test.cpp)
+    ${SRC_FILES}
+    ${credentialsfetcher_proto_sources}
+    ${credentialsfetcher_proto_headers}
+    ${credentialsfetcher_grpc_sources}
+    ${credentialsfetcher_grpc_headers}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../auth/kerberos/src/krb.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../auth/kinit_client/kinit.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../auth/kinit_client/kinit_kdb.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../metadata/src/metadata.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../metadata/tests/metadata_test.cpp)
 
 find_path(GLIB_INCLUDE_DIR glib.h "/usr/include" "/usr/include/glib-2.0")
 find_path(GLIB_CONFIG_DIR glibconfig.h "/usr/include" "/usr/lib64/glib-2.0/include")
 
 target_include_directories(cf_gmsa_service_private
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../common
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../auth/kinit_client
         ${GLIB_INCLUDE_DIR}
         ${GLIB_CONFIG_DIR}
-	    ${CMAKE_BINARY_DIR})
+        ${CMAKE_BINARY_DIR})
 
 target_link_libraries(cf_gmsa_service_private
         ${_PROTOBUF_LIBPROTOBUF}
@@ -53,8 +56,9 @@ target_link_libraries(cf_gmsa_service_private
         ${_GRPC_GRPCPP}
         systemd
         glib-2.0
-        boost_filesystem)
-
+        boost_filesystem
+        krb5 kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
+        com_err krb5support resolv)
 
 enable_testing()
 add_subdirectory(tests)

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(auth)
 add_subdirectory (kerberos)
 
-FILE(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS kerberos/src/*.cpp kerberos/src/*.c)
+FILE(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS kerberos/src/*.cpp kerberos/src/*.c kinit_client/*.c)
 
 set(auth "${SRC_FILES}" PARENT_SCOPE)
 

--- a/auth/kinit_client/CMakeLists.txt
+++ b/auth/kinit_client/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(kinit_client)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+
+FILE(GLOB SRC_FILES *.c)
+
+set(kinit_client "${SRC_FILES}" PARENT_SCOPE)

--- a/auth/kinit_client/autoconf.h
+++ b/auth/kinit_client/autoconf.h
@@ -1,0 +1,761 @@
+/* include/autoconf.h.  Generated from autoconf.h.in by configure.  */
+/* include/autoconf.h.in.  Generated from configure.ac by autoheader.  */
+
+
+#ifndef KRB5_AUTOCONF_H
+#define KRB5_AUTOCONF_H
+
+
+/* Define if AES-NI support is enabled */
+/* #undef AESNI */
+
+/* Define if socket can't be bound to 0.0.0.0 */
+/* #undef BROKEN_STREAMS_SOCKETS */
+
+/* Define if va_list objects can be simply copied by assignment. */
+/* #undef CAN_COPY_VA_LIST */
+
+/* Define to reduce code size even if it means more cpu usage */
+/* #undef CONFIG_SMALL */
+
+/* Define if __attribute__((constructor)) works */
+#define CONSTRUCTOR_ATTR_WORKS 1
+
+/* Define to use OpenSSL crypto library */
+/* #undef CRYPTO_OPENSSL */
+
+/* Define to default ccache name */
+#define DEFCCNAME "FILE:/tmp/krb5cc_%{uid}"
+
+/* Define to default client keytab name */
+#define DEFCKTNAME "FILE:/usr/local/var/krb5/user/%{euid}/client.keytab"
+
+/* Define to default keytab name */
+#define DEFKTNAME "FILE:/etc/krb5.keytab"
+
+/* Define if library initialization should be delayed until first use */
+#define DELAY_INITIALIZER 1
+
+/* Define if __attribute__((destructor)) works */
+#define DESTRUCTOR_ATTR_WORKS 1
+
+/* Define to disable PKINIT plugin support */
+#define DISABLE_PKINIT 1
+
+/* Define if LDAP KDB support within the Kerberos library (mainly ASN.1 code)
+   should be enabled. */
+/* #undef ENABLE_LDAP */
+
+/* Define if translation functions should be used. */
+#define ENABLE_NLS 1
+
+/* Define if thread support enabled */
+#define ENABLE_THREADS 1
+
+/* Define as return type of endrpcent */
+#define ENDRPCENT_TYPE void
+
+/* Define to the type of elements in the array set by `getgroups'. Usually
+   this is either `int' or `gid_t'. */
+#define GETGROUPS_T gid_t
+
+/* Define if gethostbyname_r returns int rather than struct hostent * */
+#define GETHOSTBYNAME_R_RETURNS_INT 1
+
+/* Type of getpeername second argument. */
+#define GETPEERNAME_ARG3_TYPE GETSOCKNAME_ARG3_TYPE
+
+/* Define if getpwnam_r exists but takes only 4 arguments (e.g., POSIX draft 6
+   implementations like some Solaris releases). */
+/* #undef GETPWNAM_R_4_ARGS */
+
+/* Define if getpwnam_r returns an int */
+#define GETPWNAM_R_RETURNS_INT 1
+
+/* Define if getpwuid_r exists but takes only 4 arguments (e.g., POSIX draft 6
+   implementations like some Solaris releases). */
+/* #undef GETPWUID_R_4_ARGS */
+
+/* Define if getservbyname_r returns int rather than struct servent * */
+#define GETSERVBYNAME_R_RETURNS_INT 1
+
+/* Type of pointer target for argument 3 to getsockname */
+#define GETSOCKNAME_ARG3_TYPE socklen_t
+
+/* Define if gmtime_r returns int instead of struct tm pointer, as on old
+   HP-UX systems. */
+/* #undef GMTIME_R_RETURNS_INT */
+
+/* Define if va_copy macro or function is available. */
+#define HAS_VA_COPY 1
+
+/* Define to 1 if you have the `access' function. */
+#define HAVE_ACCESS 1
+
+/* Define to 1 if you have the <alloca.h> header file. */
+#define HAVE_ALLOCA_H 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the `bswap16' function. */
+/* #undef HAVE_BSWAP16 */
+
+/* Define to 1 if you have the `bswap64' function. */
+/* #undef HAVE_BSWAP64 */
+
+/* Define to 1 if bswap_16 is available via byteswap.h */
+#define HAVE_BSWAP_16 1
+
+/* Define to 1 if bswap_64 is available via byteswap.h */
+#define HAVE_BSWAP_64 1
+
+/* Define if bt_rseq is available, for recursive btree traversal. */
+#define HAVE_BT_RSEQ 1
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#define HAVE_BYTESWAP_H 1
+
+/* Define to 1 if you have the `chmod' function. */
+#define HAVE_CHMOD 1
+
+/* Define if cmocka library is available. */
+/* #undef HAVE_CMOCKA */
+
+/* Define to 1 if you have the `compile' function. */
+/* #undef HAVE_COMPILE */
+
+/* Define if com_err has compatible gettext support */
+#define HAVE_COM_ERR_INTL 1
+
+/* Define to 1 if you have the <cpuid.h> header file. */
+#define HAVE_CPUID_H 1
+
+/* Define to 1 if you have the `daemon' function. */
+#define HAVE_DAEMON 1
+
+/* Define to 1 if you have the declaration of `strerror_r', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRERROR_R 1
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+   */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the `dn_skipname' function. */
+#define HAVE_DN_SKIPNAME 1
+
+/* Define to 1 if you have the <endian.h> header file. */
+#define HAVE_ENDIAN_H 1
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if you have the `EVP_PKEY_get_bn_param' function. */
+/* #undef HAVE_EVP_PKEY_GET_BN_PARAM */
+
+/* Define to 1 if you have the `explicit_bzero' function. */
+#define HAVE_EXPLICIT_BZERO 1
+
+/* Define to 1 if you have the `explicit_memset' function. */
+/* #undef HAVE_EXPLICIT_MEMSET */
+
+/* Define to 1 if you have the `fchmod' function. */
+#define HAVE_FCHMOD 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `flock' function. */
+#define HAVE_FLOCK 1
+
+/* Define to 1 if you have the `fnmatch' function. */
+#define HAVE_FNMATCH 1
+
+/* Define to 1 if you have the <fnmatch.h> header file. */
+#define HAVE_FNMATCH_H 1
+
+/* Define if you have the getaddrinfo function */
+#define HAVE_GETADDRINFO 1
+
+/* Define to 1 if you have the `getcwd' function. */
+#define HAVE_GETCWD 1
+
+/* Define to 1 if you have the `getenv' function. */
+#define HAVE_GETENV 1
+
+/* Define to 1 if you have the `geteuid' function. */
+#define HAVE_GETEUID 1
+
+/* Define if gethostbyname_r exists and its return type is known */
+#define HAVE_GETHOSTBYNAME_R 1
+
+/* Define to 1 if you have the `getnameinfo' function. */
+#define HAVE_GETNAMEINFO 1
+
+/* Define if system getopt should be used. */
+#define HAVE_GETOPT 1
+
+/* Define if system getopt_long should be used. */
+#define HAVE_GETOPT_LONG 1
+
+/* Define if getpwnam_r is available and useful. */
+#define HAVE_GETPWNAM_R 1
+
+/* Define if getpwuid_r is available and useful. */
+#define HAVE_GETPWUID_R 1
+
+/* Define to 1 if you have the `getresgid' function. */
+#define HAVE_GETRESGID 1
+
+/* Define to 1 if you have the `getresuid' function. */
+#define HAVE_GETRESUID 1
+
+/* Define if getservbyname_r exists and its return type is known */
+#define HAVE_GETSERVBYNAME_R 1
+
+/* Have the gettimeofday function */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `getusershell' function. */
+#define HAVE_GETUSERSHELL 1
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#define HAVE_GMTIME_R 1
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H 1
+
+/* Define to 1 if you have the `inet_ntop' function. */
+#define HAVE_INET_NTOP 1
+
+/* Define to 1 if you have the `inet_pton' function. */
+#define HAVE_INET_PTON 1
+
+/* Define to 1 if the system has the type `int16_t'. */
+#define HAVE_INT16_T 1
+
+/* Define to 1 if the system has the type `int32_t'. */
+#define HAVE_INT32_T 1
+
+/* Define to 1 if the system has the type `int8_t'. */
+#define HAVE_INT8_T 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <keyutils.h> header file. */
+/* #undef HAVE_KEYUTILS_H */
+
+/* Define to 1 if you have the <lber.h> header file. */
+/* #undef HAVE_LBER_H */
+
+/* Define to 1 if you have the <ldap.h> header file. */
+/* #undef HAVE_LDAP_H */
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+/* #undef HAVE_LIBCRYPTO */
+
+/* Define if building with libedit. */
+/* #undef HAVE_LIBEDIT */
+
+/* Define to 1 if you have the `nsl' library (-lnsl). */
+/* #undef HAVE_LIBNSL */
+
+/* Define to 1 if you have the `resolv' library (-lresolv). */
+#define HAVE_LIBRESOLV 1
+
+/* Define to 1 if you have the `socket' library (-lsocket). */
+/* #undef HAVE_LIBSOCKET */
+
+/* Define if the util library is available */
+#define HAVE_LIBUTIL 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have the `localtime_r' function. */
+#define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <machine/byte_order.h> header file. */
+/* #undef HAVE_MACHINE_BYTE_ORDER_H */
+
+/* Define to 1 if you have the <machine/endian.h> header file. */
+/* #undef HAVE_MACHINE_ENDIAN_H */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `mkstemp' function. */
+#define HAVE_MKSTEMP 1
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H 1
+
+/* Define if netdb.h declares h_errno */
+#define HAVE_NETDB_H_H_ERRNO 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the `ns_initparse' function. */
+#define HAVE_NS_INITPARSE 1
+
+/* Define to 1 if you have the `ns_name_uncompress' function. */
+#define HAVE_NS_NAME_UNCOMPRESS 1
+
+/* Define to 1 if you have the <paths.h> header file. */
+#define HAVE_PATHS_H 1
+
+/* Define if persistent keyrings are supported */
+/* #undef HAVE_PERSISTENT_KEYRING */
+
+/* Define to 1 if you have the <poll.h> header file. */
+#define HAVE_POLL_H 1
+
+/* Define if #pragma weak references work */
+#define HAVE_PRAGMA_WEAK_REF 1
+
+/* Define if you have POSIX threads libraries and header files. */
+#define HAVE_PTHREAD 1
+
+/* Define to 1 if you have the `pthread_once' function. */
+#define HAVE_PTHREAD_ONCE 1
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the `pthread_rwlock_init' function. */
+#define HAVE_PTHREAD_RWLOCK_INIT 1
+
+/* Define if pthread_rwlock_init is provided in the thread library. */
+#define HAVE_PTHREAD_RWLOCK_INIT_IN_THREAD_LIB 1
+
+/* Define to 1 if you have the <pwd.h> header file. */
+#define HAVE_PWD_H 1
+
+/* Define if building with GNU Readline. */
+/* #undef HAVE_READLINE */
+
+/* Define if regcomp exists and functions */
+#define HAVE_REGCOMP 1
+
+/* Define to 1 if you have the `regexec' function. */
+#define HAVE_REGEXEC 1
+
+/* Define to 1 if you have the <regexpr.h> header file. */
+/* #undef HAVE_REGEXPR_H */
+
+/* Define to 1 if you have the <regex.h> header file. */
+#define HAVE_REGEX_H 1
+
+/* Define to 1 if you have the `res_nclose' function. */
+#define HAVE_RES_NCLOSE 1
+
+/* Define to 1 if you have the `res_ndestroy' function. */
+/* #undef HAVE_RES_NDESTROY */
+
+/* Define to 1 if you have the `res_ninit' function. */
+#define HAVE_RES_NINIT 1
+
+/* Define to 1 if you have the `res_nsearch' function. */
+#define HAVE_RES_NSEARCH 1
+
+/* Define to 1 if you have the `res_search' function */
+#define HAVE_RES_SEARCH 1
+
+/* Define to 1 if you have the `re_comp' function. */
+#define HAVE_RE_COMP 1
+
+/* Define to 1 if you have the `re_exec' function. */
+#define HAVE_RE_EXEC 1
+
+/* Define to 1 if you have the <sasl/sasl.h> header file. */
+/* #undef HAVE_SASL_SASL_H */
+
+/* Define if struct sockaddr contains sa_len */
+/* #undef HAVE_SA_LEN */
+
+/* Define to 1 if you have the `secure_getenv' function. */
+#define HAVE_SECURE_GETENV 1
+
+/* Define to 1 if you have the `setegid' function. */
+#define HAVE_SETEGID 1
+
+/* Define to 1 if you have the `setenv' function. */
+#define HAVE_SETENV 1
+
+/* Define to 1 if you have the `seteuid' function. */
+#define HAVE_SETEUID 1
+
+/* Define if setluid provided in OSF/1 security library */
+/* #undef HAVE_SETLUID */
+
+/* Define to 1 if you have the `setregid' function. */
+#define HAVE_SETREGID 1
+
+/* Define to 1 if you have the `setresgid' function. */
+#define HAVE_SETRESGID 1
+
+/* Define to 1 if you have the `setresuid' function. */
+#define HAVE_SETRESUID 1
+
+/* Define to 1 if you have the `setreuid' function. */
+#define HAVE_SETREUID 1
+
+/* Define to 1 if you have the `setsid' function. */
+#define HAVE_SETSID 1
+
+/* Define to 1 if you have the `setvbuf' function. */
+#define HAVE_SETVBUF 1
+
+/* Define if there is a socklen_t type. If not, probably use size_t */
+#define HAVE_SOCKLEN_T 1
+
+/* Define to 1 if you have the `srand' function. */
+#define HAVE_SRAND 1
+
+/* Define to 1 if you have the `srand48' function. */
+#define HAVE_SRAND48 1
+
+/* Define to 1 if you have the `srandom' function. */
+#define HAVE_SRANDOM 1
+
+/* Define to 1 if the system has the type `ssize_t'. */
+#define HAVE_SSIZE_T 1
+
+/* Define to 1 if you have the `stat' function. */
+#define HAVE_STAT 1
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#define HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `step' function. */
+/* #undef HAVE_STEP */
+
+/* Define to 1 if you have the `strchr' function. */
+#define HAVE_STRCHR 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the `strerror_r' function. */
+#define HAVE_STRERROR_R 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strlcpy' function. */
+/* #undef HAVE_STRLCPY */
+
+/* Define to 1 if you have the `strptime' function. */
+#define HAVE_STRPTIME 1
+
+/* Define to 1 if the system has the type `struct cmsghdr'. */
+#define HAVE_STRUCT_CMSGHDR 1
+
+/* Define if there is a struct if_laddrconf. */
+/* #undef HAVE_STRUCT_IF_LADDRCONF */
+
+/* Define to 1 if the system has the type `struct in6_pktinfo'. */
+#define HAVE_STRUCT_IN6_PKTINFO 1
+
+/* Define to 1 if the system has the type `struct in_pktinfo'. */
+#define HAVE_STRUCT_IN_PKTINFO 1
+
+/* Define if there is a struct lifconf. */
+/* #undef HAVE_STRUCT_LIFCONF */
+
+/* Define to 1 if the system has the type `struct rt_msghdr'. */
+/* #undef HAVE_STRUCT_RT_MSGHDR */
+
+/* Define to 1 if the system has the type `struct sockaddr_storage'. */
+#define HAVE_STRUCT_SOCKADDR_STORAGE 1
+
+/* Define to 1 if `st_mtimensec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_MTIMENSEC */
+
+/* Define to 1 if `st_mtimespec.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC */
+
+/* Define to 1 if `st_mtim.tv_nsec' is a member of `struct stat'. */
+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+
+/* Define to 1 if you have the <sys/bswap.h> header file. */
+/* #undef HAVE_SYS_BSWAP_H */
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define if sys_errlist in libc */
+/* #undef HAVE_SYS_ERRLIST */
+
+/* Define to 1 if you have the <sys/file.h> header file. */
+#define HAVE_SYS_FILE_H 1
+
+/* Define to 1 if you have the <sys/filio.h> header file. */
+/* #undef HAVE_SYS_FILIO_H */
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/sockio.h> header file. */
+/* #undef HAVE_SYS_SOCKIO_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+#define HAVE_SYS_UIO_H 1
+
+/* Define to 1 if you have the `timegm' function. */
+#define HAVE_TIMEGM 1
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `unsetenv' function. */
+#define HAVE_UNSETENV 1
+
+/* Define to 1 if the system has the type `u_char'. */
+#define HAVE_U_CHAR 1
+
+/* Define to 1 if the system has the type `u_int'. */
+#define HAVE_U_INT 1
+
+/* Define to 1 if the system has the type `u_int16_t'. */
+#define HAVE_U_INT16_T 1
+
+/* Define to 1 if the system has the type `u_int32_t'. */
+#define HAVE_U_INT32_T 1
+
+/* Define to 1 if the system has the type `u_int8_t'. */
+#define HAVE_U_INT8_T 1
+
+/* Define to 1 if the system has the type `u_long'. */
+#define HAVE_U_LONG 1
+
+/* Define to 1 if you have the `vasprintf' function. */
+#define HAVE_VASPRINTF 1
+
+/* Define to 1 if you have the `vsnprintf' function. */
+#define HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the `vsprintf' function. */
+#define HAVE_VSPRINTF 1
+
+/* Define to 1 if the system has the type `__int128_t'. */
+#define HAVE___INT128_T 1
+
+/* Define to 1 if the system has the type `__uint128_t'. */
+#define HAVE___UINT128_T 1
+
+/* Define if errno.h declares perror */
+/* #undef HDR_HAS_PERROR */
+
+/* May need to be defined to enable IPv6 support, for example on IRIX */
+/* #undef INET6 */
+
+/* Define if MIT Project Athena default configuration should be used */
+/* #undef KRB5_ATHENA_COMPAT */
+
+/* Define for DNS support of locating realms and KDCs */
+#define KRB5_DNS_LOOKUP 1
+
+/* Define to enable DNS lookups of Kerberos realm names */
+/* #undef KRB5_DNS_LOOKUP_REALM */
+
+/* Define if the KDC should return only vague error codes to clients */
+/* #undef KRBCONF_VAGUE_ERRORS */
+
+/* define if the system header files are missing prototype for daemon() */
+/* #undef NEED_DAEMON_PROTO */
+
+/* Define if in6addr_any is not defined in libc */
+/* #undef NEED_INSIXADDR_ANY */
+
+/* define if the system header files are missing prototype for
+   ss_execute_command() */
+/* #undef NEED_SS_EXECUTE_COMMAND_PROTO */
+
+/* define if the system header files are missing prototype for strptime() */
+/* #undef NEED_STRPTIME_PROTO */
+
+/* define if the system header files are missing prototype for swab() */
+/* #undef NEED_SWAB_PROTO */
+
+/* Define if need to declare sys_errlist */
+/* #undef NEED_SYS_ERRLIST */
+
+/* define if the system header files are missing prototype for vasprintf() */
+/* #undef NEED_VASPRINTF_PROTO */
+
+/* Define if the KDC should use no lookaside cache */
+/* #undef NOCACHE */
+
+/* Define if references to pthread routines should be non-weak. */
+/* #undef NO_WEAK_PTHREADS */
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "krb5-bugs@mit.edu"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "Kerberos 5"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "Kerberos 5 1.21-prerelease"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "krb5"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.21-prerelease"
+
+/* Default PKCS11 module name */
+#define PKCS11_MODNAME "opensc-pkcs11.so"
+
+/* Define if setjmp indicates POSIX interface */
+/* #undef POSIX_SETJMP */
+
+/* Define if POSIX signal handling is used */
+#define POSIX_SIGNALS 1
+
+/* Define if termios.h exists and tcsetattr exists */
+#define POSIX_TERMIOS 1
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Define as return type of setrpcent */
+#define SETRPCENT_TYPE void
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 8
+
+/* The size of `time_t', as computed by sizeof. */
+#define SIZEOF_TIME_T 8
+
+/* Define to use OpenSSL for SPAKE preauth */
+/* #undef SPAKE_OPENSSL */
+
+/* Define for static plugin linkage */
+/* #undef STATIC_PLUGINS */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if strerror_r returns char *. */
+#define STRERROR_R_CHAR_P 1
+
+/* Define if sys_errlist is defined in errno.h */
+/* #undef SYS_ERRLIST_DECLARED */
+
+/* Define if no TLS implementation is selected */
+#define TLS_IMPL_NONE 1
+
+/* Define if TLS implementation is OpenSSL */
+/* #undef TLS_IMPL_OPENSSL */
+
+/* Define to build macOS CCAPI client */
+/* #undef USE_CCAPI_MACOS */
+
+/* Define if you have dirent.h functionality */
+#define USE_DIRENT_H 1
+
+/* Define if dlopen should be used */
+#define USE_DLOPEN 1
+
+/* Define if the keyring ccache should be enabled */
+/* #undef USE_KEYRING_CCACHE */
+
+/* Define if link-time options for library finalization will be used */
+/* #undef USE_LINKER_FINI_OPTION */
+
+/* Define if link-time options for library initialization will be used */
+/* #undef USE_LINKER_INIT_OPTION */
+
+/* Define if sigprocmask should be used */
+#define USE_SIGPROCMASK 1
+
+/* Define if wait takes int as a argument */
+#define WAIT_USES_INT 1
+
+/* Define to enable extensions in glibc */
+#define _GNU_SOURCE 1
+
+/* Define to enable C11 extensions */
+#define __STDC_WANT_LIB_EXT1__ 1
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+/* #undef gid_t */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef mode_t */
+
+/* Define to `long int' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to `long' if <sys/types.h> does not define. */
+/* #undef time_t */
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+/* #undef uid_t */
+
+
+#if defined(__GNUC__) && !defined(inline)
+/* Silence gcc pedantic warnings about ANSI C.  */
+# define inline __inline__
+#endif
+#endif /* KRB5_AUTOCONF_H */
+

--- a/auth/kinit_client/extern.h
+++ b/auth/kinit_client/extern.h
@@ -1,0 +1,33 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* clients/kinit/extern.h - Global declarations for kinit */
+/*
+ * Copyright (C) 2010 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+#ifndef KINIT_EXTERN_H
+#define KINIT_EXTERN_H
+
+krb5_error_code kinit_kdb_init(krb5_context *pcontext, char *realm);
+void kinit_kdb_fini(void);
+
+#endif /* KINIT_EXTERN_H */

--- a/auth/kinit_client/k5-buf.h
+++ b/auth/kinit_client/k5-buf.h
@@ -1,0 +1,177 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-buf.h - k5buf interface declarations */
+/*
+ * Copyright 2008 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+#ifndef K5_BUF_H
+#define K5_BUF_H
+
+#include <stdarg.h>
+#include <string.h>
+
+/*
+ * The k5buf module is intended to allow multi-step string construction in a
+ * fixed or dynamic buffer without the need to check for a failure at each step
+ * (and without aborting on malloc failure).  If an allocation failure occurs
+ * or the fixed buffer runs out of room, the buffer will be set to an error
+ * state which can be detected with k5_buf_status.  Data in a buffer is not
+ * automatically terminated with a zero byte; call k5_buf_cstring() to use the
+ * contents as a C string.
+ *
+ * k5buf structures are usually stack-allocated.  Do not put k5buf structure
+ * pointers into public APIs.  It is okay to reference the data and len fields
+ * of a buffer (they will be NULL/0 if the buffer is in an error state), but do
+ * not change them.
+ */
+
+/* Buffer type values */
+enum k5buftype { K5BUF_ERROR, K5BUF_FIXED, K5BUF_DYNAMIC, K5BUF_DYNAMIC_ZAP };
+
+struct k5buf {
+    enum k5buftype buftype;
+    void *data;
+    size_t space;
+    size_t len;
+};
+
+#define EMPTY_K5BUF { K5BUF_ERROR }
+
+/* Initialize a k5buf using a fixed-sized, existing buffer.  SPACE must be
+ * more than zero, or an assertion failure will result. */
+void k5_buf_init_fixed(struct k5buf *buf, void *data, size_t space);
+
+/* Initialize a k5buf using an internally allocated dynamic buffer. */
+void k5_buf_init_dynamic(struct k5buf *buf);
+
+/* Initialize a k5buf using an internally allocated dynamic buffer, zeroing
+ * memory when reallocating or freeing. */
+void k5_buf_init_dynamic_zap(struct k5buf *buf);
+
+/* Add a C string to BUF. */
+void k5_buf_add(struct k5buf *buf, const char *data);
+
+/* Add a counted series of bytes to BUF. */
+void k5_buf_add_len(struct k5buf *buf, const void *data, size_t len);
+
+/* Add sprintf-style formatted data to BUF.  For a fixed-length buffer this
+ * operation will fail if there isn't room for a zero terminator. */
+void k5_buf_add_fmt(struct k5buf *buf, const char *fmt, ...)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 3)))
+#endif
+    ;
+
+/* Add sprintf-style formatted data to BUF, with a va_list.  The value of ap is
+ * undefined after the call. */
+void k5_buf_add_vfmt(struct k5buf *buf, const char *fmt, va_list ap)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 0)))
+#endif
+    ;
+
+/* Without changing the length of buf, ensure that there is a zero byte after
+ * buf.data and return it.  Return NULL on error. */
+char *k5_buf_cstring(struct k5buf *buf);
+
+/* Extend the length of buf by len and return a pointer to the reserved space,
+ * to be filled in by the caller.  Return NULL on error. */
+void *k5_buf_get_space(struct k5buf *buf, size_t len);
+
+/* Truncate BUF.  LEN must be between 0 and the existing buffer
+ * length, or an assertion failure will result. */
+void k5_buf_truncate(struct k5buf *buf, size_t len);
+
+/* Return ENOMEM if buf is in an error state, 0 otherwise. */
+int k5_buf_status(struct k5buf *buf);
+
+/*
+ * Free the storage used in the dynamic buffer BUF.  The caller may choose to
+ * take responsibility for freeing the data pointer instead of using this
+ * function.  If BUF is a fixed buffer, an assertion failure will result.
+ * Freeing a buffer in the error state, a buffer initialized with EMPTY_K5BUF,
+ * or a zeroed k5buf structure is a no-op.
+ */
+void k5_buf_free(struct k5buf *buf);
+
+static inline void
+k5_buf_add_byte(struct k5buf *buf, uint8_t val)
+{
+    k5_buf_add_len(buf, &val, 1);
+}
+
+static inline void
+k5_buf_add_uint16_be(struct k5buf *buf, uint16_t val)
+{
+    void *p = k5_buf_get_space(buf, 2);
+
+    if (p != NULL)
+        store_16_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint16_le(struct k5buf *buf, uint16_t val)
+{
+    void *p = k5_buf_get_space(buf, 2);
+
+    if (p != NULL)
+        store_16_le(val, p);
+}
+
+static inline void
+k5_buf_add_uint32_be(struct k5buf *buf, uint32_t val)
+{
+    void *p = k5_buf_get_space(buf, 4);
+
+    if (p != NULL)
+        store_32_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint32_le(struct k5buf *buf, uint32_t val)
+{
+    void *p = k5_buf_get_space(buf, 4);
+
+    if (p != NULL)
+        store_32_le(val, p);
+}
+
+static inline void
+k5_buf_add_uint64_be(struct k5buf *buf, uint64_t val)
+{
+    void *p = k5_buf_get_space(buf, 8);
+
+    if (p != NULL)
+        store_64_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint64_le(struct k5buf *buf, uint64_t val)
+{
+    void *p = k5_buf_get_space(buf, 8);
+
+    if (p != NULL)
+        store_64_le(val, p);
+}
+
+#endif /* K5_BUF_H */

--- a/auth/kinit_client/k5-err.h
+++ b/auth/kinit_client/k5-err.h
@@ -1,0 +1,69 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-err.h */
+/*
+ * Copyright 2006, 2007 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/*
+ *
+ * Error-message handling
+ */
+
+#ifndef K5_ERR_H
+#define K5_ERR_H
+
+#if defined(_MSDOS) || defined(_WIN32)
+#include <win-mac.h>
+#endif
+#ifndef KRB5_CALLCONV
+#define KRB5_CALLCONV
+#define KRB5_CALLCONV_C
+#endif
+
+#include <stdarg.h>
+
+struct errinfo {
+    long code;
+    char *msg;
+};
+#define EMPTY_ERRINFO { 0, NULL }
+
+void k5_set_error(struct errinfo *ep, long code, const char *fmt, ...)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 3, 4)))
+#endif
+    ;
+
+void k5_vset_error(struct errinfo *ep, long code, const char *fmt,
+                   va_list args)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 3, 0)))
+#endif
+    ;
+
+const char *k5_get_error(struct errinfo *ep, long code);
+void k5_free_error(struct errinfo *ep, const char *msg);
+void k5_clear_error(struct errinfo *ep);
+void k5_set_error_info_callout_fn(const char *(KRB5_CALLCONV *f)(long));
+
+#endif /* K5_ERR_H */

--- a/auth/kinit_client/k5-gmt_mktime.h
+++ b/auth/kinit_client/k5-gmt_mktime.h
@@ -1,0 +1,43 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-gmt_mktime.h */
+/*
+ * Copyright 2008 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/*
+ *
+ * GMT struct tm conversion
+ *
+ * Because of ordering of things in the UNIX build, we can't just keep
+ * the declaration in k5-int.h and include it in
+ * util/support/gmt_mktime.c, since k5-int.h includes krb5.h which
+ * hasn't been built when gmt_mktime.c gets compiled.  Hence this
+ * silly little helper header.
+ */
+
+#ifndef K5_GMT_MKTIME_H
+#define K5_GMT_MKTIME_H
+
+time_t krb5int_gmt_mktime (struct tm *);
+
+#endif /* K5_GMT_MKTIME_H */

--- a/auth/kinit_client/k5-int-pkinit.h
+++ b/auth/kinit_client/k5-int-pkinit.h
@@ -1,0 +1,204 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * COPYRIGHT (C) 2006
+ * THE REGENTS OF THE UNIVERSITY OF MICHIGAN
+ * ALL RIGHTS RESERVED
+ *
+ * Permission is granted to use, copy, create derivative works
+ * and redistribute this software and such derivative works
+ * for any purpose, so long as the name of The University of
+ * Michigan is not used in any advertising or publicity
+ * pertaining to the use of distribution of this software
+ * without specific, written prior authorization.  If the
+ * above copyright notice or any other identification of the
+ * University of Michigan is included in any copy of any
+ * portion of this software, then the disclaimer below must
+ * also be included.
+ *
+ * THIS SOFTWARE IS PROVIDED AS IS, WITHOUT REPRESENTATION
+ * FROM THE UNIVERSITY OF MICHIGAN AS TO ITS FITNESS FOR ANY
+ * PURPOSE, AND WITHOUT WARRANTY BY THE UNIVERSITY OF
+ * MICHIGAN OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * REGENTS OF THE UNIVERSITY OF MICHIGAN SHALL NOT BE LIABLE
+ * FOR ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OF THE SOFTWARE, EVEN
+ * IF IT HAS BEEN OR IS HEREAFTER ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGES.
+ */
+
+#ifndef _KRB5_INT_PKINIT_H
+#define _KRB5_INT_PKINIT_H
+
+/*
+ * pkinit structures
+ */
+
+/* PKAuthenticator */
+typedef struct _krb5_pk_authenticator {
+    krb5_int32      cusec;  /* (0..999999) */
+    krb5_timestamp  ctime;
+    krb5_int32      nonce;  /* (0..4294967295) */
+    krb5_checksum   paChecksum;
+    krb5_data      *freshnessToken;
+} krb5_pk_authenticator;
+
+/* AlgorithmIdentifier */
+typedef struct _krb5_algorithm_identifier {
+    krb5_data algorithm;      /* OID */
+    krb5_data parameters; /* Optional */
+} krb5_algorithm_identifier;
+
+/** AuthPack from RFC 4556*/
+typedef struct _krb5_auth_pack {
+    krb5_pk_authenticator       pkAuthenticator;
+    krb5_data                   clientPublicValue; /* Optional */
+    krb5_algorithm_identifier   **supportedCMSTypes; /* Optional */
+    krb5_data                   clientDHNonce; /* Optional */
+    krb5_data                   **supportedKDFs; /* OIDs of KDFs; OPTIONAL */
+} krb5_auth_pack;
+
+/* ExternalPrincipalIdentifier */
+typedef struct _krb5_external_principal_identifier {
+    krb5_data subjectName; /* Optional */
+    krb5_data issuerAndSerialNumber; /* Optional */
+    krb5_data subjectKeyIdentifier; /* Optional */
+} krb5_external_principal_identifier;
+
+/* PA-PK-AS-REQ (rfc4556 -- PA TYPE 16) */
+typedef struct _krb5_pa_pk_as_req {
+    krb5_data signedAuthPack;
+    krb5_external_principal_identifier **trustedCertifiers; /* Optional array */
+    krb5_data kdcPkId; /* Optional */
+} krb5_pa_pk_as_req;
+
+/** Pkinit DHRepInfo */
+typedef struct _krb5_dh_rep_info {
+    krb5_data dhSignedData;
+    krb5_data serverDHNonce; /* Optional */
+    krb5_data *kdfID; /* OID of selected KDF OPTIONAL */
+} krb5_dh_rep_info;
+
+/* KDCDHKeyInfo */
+typedef struct _krb5_kdc_dh_key_info {
+    krb5_data       subjectPublicKey; /* BIT STRING */
+    krb5_int32      nonce;  /* (0..4294967295) */
+    krb5_timestamp  dhKeyExpiration; /* Optional */
+} krb5_kdc_dh_key_info;
+
+/* ReplyKeyPack */
+typedef struct _krb5_reply_key_pack {
+    krb5_keyblock   replyKey;
+    krb5_checksum   asChecksum;
+} krb5_reply_key_pack;
+
+/* PA-PK-AS-REP (rfc4556 -- PA TYPE 17) */
+typedef struct _krb5_pa_pk_as_rep {
+    enum krb5_pa_pk_as_rep_selection {
+        choice_pa_pk_as_rep_UNKNOWN = -1,
+        choice_pa_pk_as_rep_dhInfo = 0,
+        choice_pa_pk_as_rep_encKeyPack = 1
+    } choice;
+    union krb5_pa_pk_as_rep_choices {
+        krb5_dh_rep_info    dh_Info;
+        krb5_data           encKeyPack;
+    } u;
+} krb5_pa_pk_as_rep;
+
+/* SP80056A OtherInfo, for pkinit algorithm agility */
+typedef struct _krb5_sp80056a_other_info {
+    krb5_algorithm_identifier algorithm_identifier;
+    krb5_principal  party_u_info;
+    krb5_principal  party_v_info;
+    krb5_data supp_pub_info;
+} krb5_sp80056a_other_info;
+
+/* PkinitSuppPubInfo, for pkinit algorithm agility */
+typedef struct _krb5_pkinit_supp_pub_info {
+    krb5_enctype      enctype;
+    krb5_data         as_req;
+    krb5_data         pk_as_rep;
+} krb5_pkinit_supp_pub_info;
+
+/*
+ * Begin "asn1.h"
+ */
+
+/*************************************************************************
+ * Prototypes for pkinit asn.1 encode routines
+ *************************************************************************/
+
+krb5_error_code
+encode_krb5_pa_pk_as_req(const krb5_pa_pk_as_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_pa_pk_as_rep(const krb5_pa_pk_as_rep *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_auth_pack(const krb5_auth_pack *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_kdc_dh_key_info(const krb5_kdc_dh_key_info *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_reply_key_pack(const krb5_reply_key_pack *, krb5_data **code);
+
+krb5_error_code
+encode_krb5_td_trusted_certifiers(krb5_external_principal_identifier *const *,
+                                  krb5_data **code);
+
+krb5_error_code
+encode_krb5_td_dh_parameters(krb5_algorithm_identifier *const *,
+                             krb5_data **code);
+
+krb5_error_code
+encode_krb5_sp80056a_other_info(const krb5_sp80056a_other_info *,
+                                krb5_data **);
+
+krb5_error_code
+encode_krb5_pkinit_supp_pub_info(const krb5_pkinit_supp_pub_info *,
+                                 krb5_data **);
+
+/*************************************************************************
+ * Prototypes for pkinit asn.1 decode routines
+ *************************************************************************/
+
+krb5_error_code
+decode_krb5_pa_pk_as_req(const krb5_data *, krb5_pa_pk_as_req **);
+
+krb5_error_code
+decode_krb5_pa_pk_as_rep(const krb5_data *, krb5_pa_pk_as_rep **);
+
+krb5_error_code
+decode_krb5_auth_pack(const krb5_data *, krb5_auth_pack **);
+
+krb5_error_code
+decode_krb5_kdc_dh_key_info(const krb5_data *, krb5_kdc_dh_key_info **);
+
+krb5_error_code
+decode_krb5_principal_name(const krb5_data *, krb5_principal_data **);
+
+krb5_error_code
+decode_krb5_reply_key_pack(const krb5_data *, krb5_reply_key_pack **);
+
+krb5_error_code
+decode_krb5_td_trusted_certifiers(const krb5_data *,
+                                  krb5_external_principal_identifier ***);
+
+krb5_error_code
+decode_krb5_td_dh_parameters(const krb5_data *, krb5_algorithm_identifier ***);
+
+krb5_error_code
+encode_krb5_enc_data(const krb5_enc_data *, krb5_data **);
+
+krb5_error_code
+encode_krb5_encryption_key(const krb5_keyblock *rep, krb5_data **code);
+
+krb5_error_code
+krb5_encrypt_helper(krb5_context context, const krb5_keyblock *key,
+                    krb5_keyusage keyusage, const krb5_data *plain,
+                    krb5_enc_data *cipher);
+
+#endif /* _KRB5_INT_PKINIT_H */

--- a/auth/kinit_client/k5-int.h
+++ b/auth/kinit_client/k5-int.h
@@ -1,0 +1,2407 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright (C) 1989,1990,1991,1992,1993,1994,1995,2000,2001,
+ * 2003,2006,2007,2008,2009 by the Massachusetts Institute of Technology,
+ * Cambridge, MA, USA.  All Rights Reserved.
+ *
+ * This software is being provided to you, the LICENSEE, by the
+ * Massachusetts Institute of Technology (M.I.T.) under the following
+ * license.  By obtaining, using and/or copying this software, you agree
+ * that you have read, understood, and will comply with these terms and
+ * conditions:
+ *
+ * Export of this software from the United States of America may
+ * require a specific license from the United States Government.
+ * It is the responsibility of any person or organization contemplating
+ * export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify and distribute
+ * this software and its documentation for any purpose and without fee or
+ * royalty is hereby granted, provided that you agree to comply with the
+ * following copyright notice and statements, including the disclaimer, and
+ * that the same appear on ALL copies of the software and documentation,
+ * including modifications that you make for internal use or for
+ * distribution:
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS", AND M.I.T. MAKES NO REPRESENTATIONS
+ * OR WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+ * limitation, M.I.T. MAKES NO REPRESENTATIONS OR WARRANTIES OF
+ * MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+ * THE LICENSED SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY
+ * PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+ *
+ * The name of the Massachusetts Institute of Technology or M.I.T. may NOT
+ * be used in advertising or publicity pertaining to distribution of the
+ * software.  Title to copyright in this software and any associated
+ * documentation shall at all times remain with M.I.T., and USER agrees to
+ * preserve same.
+ *
+ * Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ */
+/*
+ * Copyright (C) 1998 by the FundsXpress, INC.
+ *
+ * All rights reserved.
+ *
+ * Export of this software from the United States of America may require
+ * a specific license from the United States Government.  It is the
+ * responsibility of any person or organization contemplating export to
+ * obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of FundsXpress. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  FundsXpress makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*
+ * This prototype for k5-int.h (Krb5 internals include file)
+ * includes the user-visible definitions from krb5.h and then
+ * includes other definitions that are not user-visible but are
+ * required for compiling Kerberos internal routines.
+ *
+ * John Gilmore, Cygnus Support, Sat Jan 21 22:45:52 PST 1995
+ */
+
+#ifndef _KRB5_INT_H
+#define _KRB5_INT_H
+
+#ifdef KRB5_GENERAL__
+#error krb5.h included before k5-int.h
+#endif /* KRB5_GENERAL__ */
+
+#include "osconf.h"
+
+#if defined(__MACH__) && defined(__APPLE__)
+#       include <TargetConditionals.h>
+#    if TARGET_RT_MAC_CFM
+#       error "Use KfM 4.0 SDK headers for CFM compilation."
+#    endif
+#endif
+
+/*
+ * Begin "k5-config.h"
+ */
+#ifndef KRB5_CONFIG__
+#define KRB5_CONFIG__
+
+/*
+ * Machine-type definitions: PC Clone 386 running Microloss Windows
+ */
+
+#if defined(_MSDOS) || defined(_WIN32)
+#include "win-mac.h"
+
+/* Kerberos Windows initialization file */
+#define KERBEROS_INI    "kerberos.ini"
+#define INI_FILES       "Files"
+#define INI_KRB_CCACHE  "krb5cc"        /* Location of the ccache */
+#define INI_KRB5_CONF   "krb5.ini"      /* Location of krb5.conf file */
+#endif
+
+#include "autoconf.h"
+
+#ifndef KRB5_SYSTYPES__
+#define KRB5_SYSTYPES__
+
+#ifdef HAVE_SYS_TYPES_H         /* From autoconf.h */
+#include <sys/types.h>
+#else /* HAVE_SYS_TYPES_H */
+typedef unsigned long   u_long;
+typedef unsigned int    u_int;
+typedef unsigned short  u_short;
+typedef unsigned char   u_char;
+#endif /* HAVE_SYS_TYPES_H */
+#endif /* KRB5_SYSTYPES__ */
+
+
+#include "k5-platform.h"
+
+#define KRB5_KDB_MAX_LIFE       (60*60*24) /* one day */
+#define KRB5_KDB_MAX_RLIFE      (60*60*24*7) /* one week */
+#define KRB5_KDB_EXPIRATION     2145830400 /* Thu Jan  1 00:00:00 2038 UTC */
+
+/*
+ * Windows requires a different api interface to each function. Here
+ * just define it as NULL.
+ */
+#ifndef KRB5_CALLCONV
+#define KRB5_CALLCONV
+#define KRB5_CALLCONV_C
+#endif
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+/* #define KRB5_OLD_CRYPTO is done in krb5.h */
+
+#endif /* KRB5_CONFIG__ */
+
+/*
+ * End "k5-config.h"
+ */
+
+/*
+ * After loading the configuration definitions, load the Kerberos definitions.
+ */
+#include <errno.h>
+#include "krb5.h"
+#include <krb5/plugin.h>
+#include "profile.h"
+
+#include "port-sockets.h"
+#include "socket-utils.h"
+
+/* Get mutex support; currently used only for the replay cache.  */
+#include "k5-thread.h"
+
+/* Get error info support.  */
+#include "k5-err.h"
+
+/* Get string buffer support. */
+#include "k5-buf.h"
+
+/* Define tracing macros. */
+#include "k5-trace.h"
+
+/* Profile variables.  Constants are named KRB5_CONF_STRING, where STRING
+ * matches the variable name.  Keep these alphabetized. */
+#define KRB5_CONF_ACL_FILE                     "acl_file"
+#define KRB5_CONF_ADMIN_SERVER                 "admin_server"
+#define KRB5_CONF_ALLOW_DES3                   "allow_des3"
+#define KRB5_CONF_ALLOW_RC4                    "allow_rc4"
+#define KRB5_CONF_ALLOW_WEAK_CRYPTO            "allow_weak_crypto"
+#define KRB5_CONF_AUTH_TO_LOCAL                "auth_to_local"
+#define KRB5_CONF_AUTH_TO_LOCAL_NAMES          "auth_to_local_names"
+#define KRB5_CONF_CANONICALIZE                 "canonicalize"
+#define KRB5_CONF_CCACHE_TYPE                  "ccache_type"
+#define KRB5_CONF_CLOCKSKEW                    "clockskew"
+#define KRB5_CONF_DATABASE_NAME                "database_name"
+#define KRB5_CONF_DB_MODULE_DIR                "db_module_dir"
+#define KRB5_CONF_DEBUG                        "debug"
+#define KRB5_CONF_DEFAULT                      "default"
+#define KRB5_CONF_DEFAULT_CCACHE_NAME          "default_ccache_name"
+#define KRB5_CONF_DEFAULT_CLIENT_KEYTAB_NAME   "default_client_keytab_name"
+#define KRB5_CONF_DEFAULT_DOMAIN               "default_domain"
+#define KRB5_CONF_DEFAULT_KEYTAB_NAME          "default_keytab_name"
+#define KRB5_CONF_DEFAULT_PRINCIPAL_EXPIRATION "default_principal_expiration"
+#define KRB5_CONF_DEFAULT_PRINCIPAL_FLAGS      "default_principal_flags"
+#define KRB5_CONF_DEFAULT_RCACHE_NAME          "default_rcache_name"
+#define KRB5_CONF_DEFAULT_REALM                "default_realm"
+#define KRB5_CONF_DEFAULT_TGS_ENCTYPES         "default_tgs_enctypes"
+#define KRB5_CONF_DEFAULT_TKT_ENCTYPES         "default_tkt_enctypes"
+#define KRB5_CONF_DICT_FILE                    "dict_file"
+#define KRB5_CONF_DISABLE                      "disable"
+#define KRB5_CONF_DISABLE_ENCRYPTED_TIMESTAMP  "disable_encrypted_timestamp"
+#define KRB5_CONF_DISABLE_LAST_SUCCESS         "disable_last_success"
+#define KRB5_CONF_DISABLE_LOCKOUT              "disable_lockout"
+#define KRB5_CONF_DISABLE_PAC                  "disable_pac"
+#define KRB5_CONF_DNS_CANONICALIZE_HOSTNAME    "dns_canonicalize_hostname"
+#define KRB5_CONF_DNS_FALLBACK                 "dns_fallback"
+#define KRB5_CONF_DNS_LOOKUP_KDC               "dns_lookup_kdc"
+#define KRB5_CONF_DNS_LOOKUP_REALM             "dns_lookup_realm"
+#define KRB5_CONF_DNS_URI_LOOKUP               "dns_uri_lookup"
+#define KRB5_CONF_DOMAIN_REALM                 "domain_realm"
+#define KRB5_CONF_ENABLE_ONLY                  "enable_only"
+#define KRB5_CONF_ENCRYPTED_CHALLENGE_INDICATOR "encrypted_challenge_indicator"
+#define KRB5_CONF_ENFORCE_OK_AS_DELEGATE       "enforce_ok_as_delegate"
+#define KRB5_CONF_ERR_FMT                      "err_fmt"
+#define KRB5_CONF_EXTRA_ADDRESSES              "extra_addresses"
+#define KRB5_CONF_FORWARDABLE                  "forwardable"
+#define KRB5_CONF_HOST_BASED_SERVICES          "host_based_services"
+#define KRB5_CONF_HTTP_ANCHORS                 "http_anchors"
+#define KRB5_CONF_IGNORE_ACCEPTOR_HOSTNAME     "ignore_acceptor_hostname"
+#define KRB5_CONF_IPROP_ENABLE                 "iprop_enable"
+#define KRB5_CONF_IPROP_LISTEN                 "iprop_listen"
+#define KRB5_CONF_IPROP_LOGFILE                "iprop_logfile"
+#define KRB5_CONF_IPROP_MASTER_ULOGSIZE        "iprop_master_ulogsize"
+#define KRB5_CONF_IPROP_PORT                   "iprop_port"
+#define KRB5_CONF_IPROP_RESYNC_TIMEOUT         "iprop_resync_timeout"
+#define KRB5_CONF_IPROP_REPLICA_POLL           "iprop_replica_poll"
+#define KRB5_CONF_IPROP_SLAVE_POLL             "iprop_slave_poll"
+#define KRB5_CONF_IPROP_ULOGSIZE               "iprop_ulogsize"
+#define KRB5_CONF_K5LOGIN_AUTHORITATIVE        "k5login_authoritative"
+#define KRB5_CONF_K5LOGIN_DIRECTORY            "k5login_directory"
+#define KRB5_CONF_KADMIND_LISTEN               "kadmind_listen"
+#define KRB5_CONF_KADMIND_PORT                 "kadmind_port"
+#define KRB5_CONF_KCM_MACH_SERVICE             "kcm_mach_service"
+#define KRB5_CONF_KCM_SOCKET                   "kcm_socket"
+#define KRB5_CONF_KDC                          "kdc"
+#define KRB5_CONF_KDCDEFAULTS                  "kdcdefaults"
+#define KRB5_CONF_KDC_DEFAULT_OPTIONS          "kdc_default_options"
+#define KRB5_CONF_KDC_LISTEN                   "kdc_listen"
+#define KRB5_CONF_KDC_MAX_DGRAM_REPLY_SIZE     "kdc_max_dgram_reply_size"
+#define KRB5_CONF_KDC_PORTS                    "kdc_ports"
+#define KRB5_CONF_KDC_TCP_PORTS                "kdc_tcp_ports"
+#define KRB5_CONF_KDC_TCP_LISTEN               "kdc_tcp_listen"
+#define KRB5_CONF_KDC_TCP_LISTEN_BACKLOG       "kdc_tcp_listen_backlog"
+#define KRB5_CONF_KDC_TIMESYNC                 "kdc_timesync"
+#define KRB5_CONF_KEY_STASH_FILE               "key_stash_file"
+#define KRB5_CONF_KPASSWD_LISTEN               "kpasswd_listen"
+#define KRB5_CONF_KPASSWD_PORT                 "kpasswd_port"
+#define KRB5_CONF_KPASSWD_SERVER               "kpasswd_server"
+#define KRB5_CONF_KRB524_SERVER                "krb524_server"
+#define KRB5_CONF_LDAP_CONNS_PER_SERVER        "ldap_conns_per_server"
+#define KRB5_CONF_LDAP_KADMIND_DN              "ldap_kadmind_dn"
+#define KRB5_CONF_LDAP_KADMIND_SASL_AUTHCID    "ldap_kadmind_sasl_authcid"
+#define KRB5_CONF_LDAP_KADMIND_SASL_AUTHZID    "ldap_kadmind_sasl_authzid"
+#define KRB5_CONF_LDAP_KADMIND_SASL_MECH       "ldap_kadmind_sasl_mech"
+#define KRB5_CONF_LDAP_KADMIND_SASL_REALM      "ldap_kadmind_sasl_realm"
+#define KRB5_CONF_LDAP_KDC_DN                  "ldap_kdc_dn"
+#define KRB5_CONF_LDAP_KDC_SASL_AUTHCID        "ldap_kdc_sasl_authcid"
+#define KRB5_CONF_LDAP_KDC_SASL_AUTHZID        "ldap_kdc_sasl_authzid"
+#define KRB5_CONF_LDAP_KDC_SASL_MECH           "ldap_kdc_sasl_mech"
+#define KRB5_CONF_LDAP_KDC_SASL_REALM          "ldap_kdc_sasl_realm"
+#define KRB5_CONF_LDAP_KERBEROS_CONTAINER_DN   "ldap_kerberos_container_dn"
+#define KRB5_CONF_LDAP_SERVERS                 "ldap_servers"
+#define KRB5_CONF_LDAP_SERVICE_PASSWORD_FILE   "ldap_service_password_file"
+#define KRB5_CONF_LIBDEFAULTS                  "libdefaults"
+#define KRB5_CONF_LOGGING                      "logging"
+#define KRB5_CONF_MAPSIZE                      "mapsize"
+#define KRB5_CONF_MASTER_KDC                   "master_kdc"
+#define KRB5_CONF_MASTER_KEY_NAME              "master_key_name"
+#define KRB5_CONF_MASTER_KEY_TYPE              "master_key_type"
+#define KRB5_CONF_MAX_LIFE                     "max_life"
+#define KRB5_CONF_MAX_READERS                  "max_readers"
+#define KRB5_CONF_MAX_RENEWABLE_LIFE           "max_renewable_life"
+#define KRB5_CONF_MODULE                       "module"
+#define KRB5_CONF_NOADDRESSES                  "noaddresses"
+#define KRB5_CONF_NOSYNC                       "nosync"
+#define KRB5_CONF_NO_HOST_REFERRAL             "no_host_referral"
+#define KRB5_CONF_PERMITTED_ENCTYPES           "permitted_enctypes"
+#define KRB5_CONF_PLUGINS                      "plugins"
+#define KRB5_CONF_PLUGIN_BASE_DIR              "plugin_base_dir"
+#define KRB5_CONF_PREFERRED_PREAUTH_TYPES      "preferred_preauth_types"
+#define KRB5_CONF_PRIMARY_KDC                  "primary_kdc"
+#define KRB5_CONF_PROXIABLE                    "proxiable"
+#define KRB5_CONF_QUALIFY_SHORTNAME            "qualify_shortname"
+#define KRB5_CONF_RDNS                         "rdns"
+#define KRB5_CONF_REALMS                       "realms"
+#define KRB5_CONF_REALM_TRY_DOMAINS            "realm_try_domains"
+#define KRB5_CONF_REJECT_BAD_TRANSIT           "reject_bad_transit"
+#define KRB5_CONF_RENEW_LIFETIME               "renew_lifetime"
+#define KRB5_CONF_RESTRICT_ANONYMOUS_TO_TGT    "restrict_anonymous_to_tgt"
+#define KRB5_CONF_SUPPORTED_ENCTYPES           "supported_enctypes"
+#define KRB5_CONF_SPAKE_PREAUTH_INDICATOR      "spake_preauth_indicator"
+#define KRB5_CONF_SPAKE_PREAUTH_KDC_CHALLENGE  "spake_preauth_kdc_challenge"
+#define KRB5_CONF_SPAKE_PREAUTH_GROUPS         "spake_preauth_groups"
+#define KRB5_CONF_TICKET_LIFETIME              "ticket_lifetime"
+#define KRB5_CONF_UDP_PREFERENCE_LIMIT         "udp_preference_limit"
+#define KRB5_CONF_UNLOCKITER                   "unlockiter"
+#define KRB5_CONF_V4_INSTANCE_CONVERT          "v4_instance_convert"
+#define KRB5_CONF_V4_REALM                     "v4_realm"
+#define KRB5_CONF_VERIFY_AP_REQ_NOFAIL         "verify_ap_req_nofail"
+#define KRB5_CONF_CLIENT_AWARE_GSS_BINDINGS    "client_aware_channel_bindings"
+
+/* Cache configuration variables */
+#define KRB5_CC_CONF_FAST_AVAIL                "fast_avail"
+#define KRB5_CC_CONF_PA_CONFIG_DATA            "pa_config_data"
+#define KRB5_CC_CONF_PA_TYPE                   "pa_type"
+#define KRB5_CC_CONF_PROXY_IMPERSONATOR        "proxy_impersonator"
+#define KRB5_CC_CONF_REFRESH_TIME              "refresh_time"
+#define KRB5_CC_CONF_START_REALM               "start_realm"
+
+/* Error codes used in KRB_ERROR protocol messages.
+   Return values of library routines are based on a different error table
+   (which allows non-ambiguous error codes between subsystems) */
+
+/* KDC errors */
+#define KDC_ERR_NONE                    0 /* No error */
+#define KDC_ERR_NAME_EXP                1 /* Client's entry in DB expired */
+#define KDC_ERR_SERVICE_EXP             2 /* Server's entry in DB expired */
+#define KDC_ERR_BAD_PVNO                3 /* Requested pvno not supported */
+#define KDC_ERR_C_OLD_MAST_KVNO         4 /* C's key encrypted in old master */
+#define KDC_ERR_S_OLD_MAST_KVNO         5 /* S's key encrypted in old master */
+#define KDC_ERR_C_PRINCIPAL_UNKNOWN     6 /* Client not found in Kerberos DB */
+#define KDC_ERR_S_PRINCIPAL_UNKNOWN     7 /* Server not found in Kerberos DB */
+#define KDC_ERR_PRINCIPAL_NOT_UNIQUE    8 /* Multiple entries in Kerberos DB */
+#define KDC_ERR_NULL_KEY                9 /* The C or S has a null key */
+#define KDC_ERR_CANNOT_POSTDATE         10 /* Tkt ineligible for postdating */
+#define KDC_ERR_NEVER_VALID             11 /* Requested starttime > endtime */
+#define KDC_ERR_POLICY                  12 /* KDC policy rejects request */
+#define KDC_ERR_BADOPTION               13 /* KDC can't do requested opt. */
+#define KDC_ERR_ENCTYPE_NOSUPP          14 /* No support for encryption type */
+#define KDC_ERR_SUMTYPE_NOSUPP          15 /* No support for checksum type */
+#define KDC_ERR_PADATA_TYPE_NOSUPP      16 /* No support for padata type */
+#define KDC_ERR_TRTYPE_NOSUPP           17 /* No support for transited type */
+#define KDC_ERR_CLIENT_REVOKED          18 /* C's creds have been revoked */
+#define KDC_ERR_SERVICE_REVOKED         19 /* S's creds have been revoked */
+#define KDC_ERR_TGT_REVOKED             20 /* TGT has been revoked */
+#define KDC_ERR_CLIENT_NOTYET           21 /* C not yet valid */
+#define KDC_ERR_SERVICE_NOTYET          22 /* S not yet valid */
+#define KDC_ERR_KEY_EXP                 23 /* Password has expired */
+#define KDC_ERR_PREAUTH_FAILED          24 /* Preauthentication failed */
+#define KDC_ERR_PREAUTH_REQUIRED        25 /* Additional preauthentication */
+                                           /* required */
+#define KDC_ERR_SERVER_NOMATCH          26 /* Requested server and */
+                                           /* ticket don't match*/
+#define KDC_ERR_MUST_USE_USER2USER      27 /* Server principal valid for */
+                                           /*   user2user only */
+#define KDC_ERR_PATH_NOT_ACCEPTED       28 /* KDC policy rejected transited */
+                                           /*   path */
+#define KDC_ERR_SVC_UNAVAILABLE         29 /* A service is not
+                                            * available that is
+                                            * required to process the
+                                            * request */
+/* Application errors */
+#define KRB_AP_ERR_BAD_INTEGRITY 31     /* Decrypt integrity check failed */
+#define KRB_AP_ERR_TKT_EXPIRED  32      /* Ticket expired */
+#define KRB_AP_ERR_TKT_NYV      33      /* Ticket not yet valid */
+#define KRB_AP_ERR_REPEAT       34      /* Request is a replay */
+#define KRB_AP_ERR_NOT_US       35      /* The ticket isn't for us */
+#define KRB_AP_ERR_BADMATCH     36      /* Ticket/authenticator don't match */
+#define KRB_AP_ERR_SKEW         37      /* Clock skew too great */
+#define KRB_AP_ERR_BADADDR      38      /* Incorrect net address */
+#define KRB_AP_ERR_BADVERSION   39      /* Protocol version mismatch */
+#define KRB_AP_ERR_MSG_TYPE     40      /* Invalid message type */
+#define KRB_AP_ERR_MODIFIED     41      /* Message stream modified */
+#define KRB_AP_ERR_BADORDER     42      /* Message out of order */
+#define KRB_AP_ERR_BADKEYVER    44      /* Key version is not available */
+#define KRB_AP_ERR_NOKEY        45      /* Service key not available */
+#define KRB_AP_ERR_MUT_FAIL     46      /* Mutual authentication failed */
+#define KRB_AP_ERR_BADDIRECTION 47      /* Incorrect message direction */
+#define KRB_AP_ERR_METHOD       48      /* Alternative authentication */
+                                        /* method required */
+#define KRB_AP_ERR_BADSEQ       49      /* Incorrect sequence numnber */
+                                        /* in message */
+#define KRB_AP_ERR_INAPP_CKSUM  50      /* Inappropriate type of */
+                                        /* checksum in message */
+#define KRB_AP_PATH_NOT_ACCEPTED 51     /* Policy rejects transited path */
+#define KRB_ERR_RESPONSE_TOO_BIG 52     /* Response too big for UDP, */
+                                        /*   retry with TCP */
+
+/* other errors */
+#define KRB_ERR_GENERIC         60      /* Generic error (description */
+                                        /* in e-text) */
+#define KRB_ERR_FIELD_TOOLONG   61      /* Field is too long for impl. */
+
+/* PKINIT server-reported errors */
+#define KDC_ERR_CLIENT_NOT_TRUSTED              62 /* client cert not trusted */
+#define KDC_ERR_KDC_NOT_TRUSTED                 63
+#define KDC_ERR_INVALID_SIG                     64 /* client signature verify failed */
+#define KDC_ERR_DH_KEY_PARAMETERS_NOT_ACCEPTED  65 /* invalid Diffie-Hellman parameters */
+#define KDC_ERR_CERTIFICATE_MISMATCH            66
+#define KRB_AP_ERR_NO_TGT                       67
+#define KDC_ERR_WRONG_REALM                     68
+#define KRB_AP_ERR_USER_TO_USER_REQUIRED        69
+#define KDC_ERR_CANT_VERIFY_CERTIFICATE         70 /* client cert not verifiable to */
+                                                   /* trusted root cert */
+#define KDC_ERR_INVALID_CERTIFICATE             71 /* client cert had invalid signature */
+#define KDC_ERR_REVOKED_CERTIFICATE             72 /* client cert was revoked */
+#define KDC_ERR_REVOCATION_STATUS_UNKNOWN       73 /* client cert revoked, reason unknown */
+#define KDC_ERR_REVOCATION_STATUS_UNAVAILABLE   74
+#define KDC_ERR_CLIENT_NAME_MISMATCH            75 /* mismatch between client cert and */
+                                                   /* principal name */
+#define KDC_ERR_INCONSISTENT_KEY_PURPOSE        77 /* bad extended key use */
+#define KDC_ERR_DIGEST_IN_CERT_NOT_ACCEPTED     78 /* bad digest algorithm in client cert */
+#define KDC_ERR_PA_CHECKSUM_MUST_BE_INCLUDED    79 /* missing paChecksum in PA-PK-AS-REQ */
+#define KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED 80 /* bad digest algorithm in SignedData */
+#define KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED 81
+#define KRB_AP_ERR_IAKERB_KDC_NOT_FOUND         85 /* The IAKERB proxy could
+                                                      not find a KDC */
+#define KRB_AP_ERR_IAKERB_KDC_NO_RESPONSE       86 /* The KDC did not respond
+                                                      to the IAKERB proxy */
+#define KDC_ERR_PREAUTH_EXPIRED                 90 /* RFC 6113 */
+#define KDC_ERR_MORE_PREAUTH_DATA_REQUIRED      91 /* RFC 6113 */
+#define KRB_ERR_MAX 127 /* err table base max offset for protocol err codes */
+
+/*
+ * A null-terminated array of this structure is returned by the KDC as
+ * the data part of the ETYPE_INFO preauth type.  It informs the
+ * client which encryption types are supported.
+ * The  same data structure is used by both etype-info and etype-info2
+ * but s2kparams must be null when encoding etype-info.
+ */
+typedef struct _krb5_etype_info_entry {
+    krb5_magic      magic;
+    krb5_enctype    etype;
+    unsigned int    length;
+    krb5_octet      *salt;
+    krb5_data s2kparams;
+} krb5_etype_info_entry;
+
+/*
+ *  This is essentially -1 without sign extension which can screw up
+ *  comparisons on 64 bit machines. If the length is this value, then
+ *  the salt data is not present. This is to distinguish between not
+ *  being set and being of 0 length.
+ */
+#define KRB5_ETYPE_NO_SALT VALID_UINT_BITS
+
+typedef krb5_etype_info_entry ** krb5_etype_info;
+
+/* RFC 4537 */
+typedef struct _krb5_etype_list {
+    int             length;
+    krb5_enctype    *etypes;
+} krb5_etype_list;
+
+/* sam_type values -- informational only */
+#define PA_SAM_TYPE_ENIGMA     1   /*  Enigma Logic */
+#define PA_SAM_TYPE_DIGI_PATH  2   /*  Digital Pathways */
+#define PA_SAM_TYPE_SKEY_K0    3   /*  S/key where  KDC has key 0 */
+#define PA_SAM_TYPE_SKEY       4   /*  Traditional S/Key */
+#define PA_SAM_TYPE_SECURID    5   /*  Security Dynamics */
+#define PA_SAM_TYPE_CRYPTOCARD 6   /*  CRYPTOCard */
+#if 1 /* XXX need to figure out who has which numbers assigned */
+#define PA_SAM_TYPE_ACTIVCARD_DEC  6   /*  ActivCard decimal mode */
+#define PA_SAM_TYPE_ACTIVCARD_HEX  7   /*  ActivCard hex mode */
+#define PA_SAM_TYPE_DIGI_PATH_HEX  8   /*  Digital Pathways hex mode */
+#endif
+#define PA_SAM_TYPE_EXP_BASE    128 /* experimental */
+#define PA_SAM_TYPE_GRAIL               (PA_SAM_TYPE_EXP_BASE+0) /* testing */
+#define PA_SAM_TYPE_SECURID_PREDICT     (PA_SAM_TYPE_EXP_BASE+1) /* special */
+
+typedef struct _krb5_sam_challenge_2 {
+    krb5_data       sam_challenge_2_body;
+    krb5_checksum   **sam_cksum;            /* Array of checksums */
+} krb5_sam_challenge_2;
+
+typedef struct _krb5_sam_challenge_2_body {
+    krb5_magic      magic;
+    krb5_int32      sam_type; /* information */
+    krb5_flags      sam_flags; /* KRB5_SAM_* values */
+    krb5_data       sam_type_name;
+    krb5_data       sam_track_id;
+    krb5_data       sam_challenge_label;
+    krb5_data       sam_challenge;
+    krb5_data       sam_response_prompt;
+    krb5_data       sam_pk_for_sad;
+    krb5_int32      sam_nonce;
+    krb5_enctype    sam_etype;
+} krb5_sam_challenge_2_body;
+
+typedef struct _krb5_sam_response_2 {
+    krb5_magic      magic;
+    krb5_int32      sam_type; /* informational */
+    krb5_flags      sam_flags; /* KRB5_SAM_* values */
+    krb5_data       sam_track_id; /* copied */
+    krb5_enc_data   sam_enc_nonce_or_sad; /* krb5_enc_sam_response_enc */
+    krb5_int32      sam_nonce;
+} krb5_sam_response_2;
+
+typedef struct _krb5_enc_sam_response_enc_2 {
+    krb5_magic      magic;
+    krb5_int32      sam_nonce;
+    krb5_data       sam_sad;
+} krb5_enc_sam_response_enc_2;
+
+/*
+ * Keep the pkinit definitions in a separate file so that the plugin
+ * only has to include k5-int-pkinit.h rather than k5-int.h
+ */
+
+#include "k5-int-pkinit.h"
+
+#define KRB5_OTP_FLAG_NEXTOTP        0x40000000
+#define KRB5_OTP_FLAG_COMBINE        0x20000000
+#define KRB5_OTP_FLAG_COLLECT_PIN    0x10000000
+#define KRB5_OTP_FLAG_NO_COLLECT_PIN 0x08000000
+#define KRB5_OTP_FLAG_ENCRYPT_NONCE  0x04000000
+#define KRB5_OTP_FLAG_SEPARATE_PIN   0x02000000
+#define KRB5_OTP_FLAG_CHECK_DIGIT    0x01000000
+
+#define KRB5_OTP_FORMAT_DECIMAL      0x00000000
+#define KRB5_OTP_FORMAT_HEXADECIMAL  0x00000001
+#define KRB5_OTP_FORMAT_ALPHANUMERIC 0x00000002
+#define KRB5_OTP_FORMAT_BINARY       0x00000003
+#define KRB5_OTP_FORMAT_BASE64       0x00000004
+
+typedef struct _krb5_otp_tokeninfo {
+    krb5_flags flags;
+    krb5_data vendor;
+    krb5_data challenge;
+    krb5_int32 length;          /* -1 for unspecified */
+    krb5_int32 format;          /* -1 for unspecified */
+    krb5_data token_id;
+    krb5_data alg_id;
+    krb5_algorithm_identifier **supported_hash_alg;
+    krb5_int32 iteration_count; /* -1 for unspecified */
+} krb5_otp_tokeninfo;
+
+typedef struct _krb5_pa_otp_challenge {
+    krb5_data nonce;
+    krb5_data service;
+    krb5_otp_tokeninfo **tokeninfo;
+    krb5_data salt;
+    krb5_data s2kparams;
+} krb5_pa_otp_challenge;
+
+typedef struct _krb5_pa_otp_req {
+    krb5_int32 flags;
+    krb5_data nonce;
+    krb5_enc_data enc_data;
+    krb5_algorithm_identifier *hash_alg;
+    krb5_int32 iteration_count; /* -1 for unspecified */
+    krb5_data otp_value;
+    krb5_data pin;
+    krb5_data challenge;
+    krb5_timestamp time;
+    krb5_data counter;
+    krb5_int32 format;          /* -1 for unspecified */
+    krb5_data token_id;
+    krb5_data alg_id;
+    krb5_data vendor;
+} krb5_pa_otp_req;
+
+typedef struct _krb5_kkdcp_message {
+    krb5_data kerb_message;
+    krb5_data target_domain;
+    krb5_int32 dclocator_hint;
+} krb5_kkdcp_message;
+
+/* Plain text of an encrypted PA-FX-COOKIE value produced by the KDC. */
+typedef struct _krb5_secure_cookie {
+    time_t time;
+    krb5_pa_data **data;
+} krb5_secure_cookie;
+
+typedef struct _krb5_pa_pac_options {
+    krb5_flags options;
+} krb5_pa_pac_options;
+
+/* In PAC options, indicates Resource-Based Constrained Delegation support. */
+#define KRB5_PA_PAC_OPTIONS_RBCD 0x10000000
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef HAVE_STRDUP
+extern char *strdup (const char *);
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#include <time.h>
+
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>                   /* struct stat, stat() */
+#endif
+
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>                  /* MAXPATHLEN */
+#endif
+
+#ifdef HAVE_SYS_FILE_H
+#include <sys/file.h>                   /* prototypes for file-related
+                                           syscalls; flags for open &
+                                           friends */
+#endif
+
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+
+#include <stdio.h>
+
+#include "k5-gmt_mktime.h"
+
+/* libos.spec */
+krb5_error_code krb5_lock_file(krb5_context, int, int);
+krb5_error_code krb5_unlock_file(krb5_context, int);
+krb5_error_code krb5_sendto_kdc(krb5_context, const krb5_data *,
+                                const krb5_data *, krb5_data *, int *, int);
+
+krb5_error_code krb5int_init_context_kdc(krb5_context *);
+
+struct derived_key {
+    krb5_data constant;
+    krb5_key dkey;
+    struct derived_key *next;
+};
+
+/* Internal structure of an opaque key identifier */
+struct krb5_key_st {
+    krb5_keyblock keyblock;
+    int refcount;
+    struct derived_key *derived;
+    /*
+     * Cache of data private to the cipher implementation, which we
+     * don't want to have to recompute for every operation.  This may
+     * include key schedules, iteration counts, etc.
+     *
+     * The cipher implementation is responsible for setting this up
+     * whenever needed, and the enc_provider key_cleanup method must
+     * then be provided to dispose of it.
+     */
+    void *cache;
+};
+
+krb5_error_code
+krb5int_arcfour_gsscrypt(const krb5_keyblock *keyblock, krb5_keyusage usage,
+                         const krb5_data *kd_data, krb5_crypto_iov *data,
+                         size_t num_data);
+
+#define K5_SHA256_HASHLEN (256 / 8)
+
+/* Write the SHA-256 hash of in (containing n elements) to out. */
+krb5_error_code
+k5_sha256(const krb5_data *in, size_t n, uint8_t out[K5_SHA256_HASHLEN]);
+
+/* Convenience function: zap and free ptr if it is non-NULL. */
+static inline void
+zapfree(void *ptr, size_t len)
+{
+    if (ptr != NULL) {
+        zap(ptr, len);
+        free(ptr);
+    }
+}
+
+/* Convenience function: zap and free zero-terminated str if it is non-NULL. */
+static inline void
+zapfreestr(void *str)
+{
+    if (str != NULL) {
+        zap(str, strlen((char *)str));
+        free(str);
+    }
+}
+
+/* Convenience function: zap and free krb5_data pointer if it is non-NULL. */
+static inline void
+zapfreedata(krb5_data *data)
+{
+    if (data != NULL) {
+        zapfree(data->data, data->length);
+        free(data);
+    }
+}
+
+void krb5int_c_free_keyblock(krb5_context, krb5_keyblock *key);
+void krb5int_c_free_keyblock_contents(krb5_context, krb5_keyblock *);
+krb5_error_code krb5int_c_init_keyblock(krb5_context, krb5_enctype enctype,
+                                        size_t length, krb5_keyblock **out);
+krb5_error_code krb5int_c_copy_keyblock(krb5_context context,
+                                        const krb5_keyblock *from,
+                                        krb5_keyblock **to);
+krb5_error_code krb5int_c_copy_keyblock_contents(krb5_context context,
+                                                 const krb5_keyblock *from,
+                                                 krb5_keyblock *to);
+
+krb5_error_code krb5_crypto_us_timeofday(krb5_timestamp *, krb5_int32 *);
+
+/*
+ * End "los-proto.h"
+ */
+
+typedef struct _krb5_os_context {
+    krb5_magic              magic;
+    krb5_int32              time_offset;
+    krb5_int32              usec_offset;
+    krb5_int32              os_flags;
+    char *                  default_ccname;
+} *krb5_os_context;
+
+/*
+ * Flags for the os_flags field
+ *
+ * KRB5_OS_TOFFSET_VALID means that the time offset fields are valid.
+ * The intention is that this facility to correct the system clocks so
+ * that they reflect the "real" time, for systems where for some
+ * reason we can't set the system clock.  Instead we calculate the
+ * offset between the system time and real time, and store the offset
+ * in the os context so that we can correct the system clock as necessary.
+ *
+ * KRB5_OS_TOFFSET_TIME means that the time offset fields should be
+ * returned as the time by the krb5 time routines.  This should only
+ * be used for testing purposes (obviously!)
+ */
+#define KRB5_OS_TOFFSET_VALID   1
+#define KRB5_OS_TOFFSET_TIME    2
+
+/* lock mode flags */
+#define KRB5_LOCKMODE_SHARED    0x0001
+#define KRB5_LOCKMODE_EXCLUSIVE 0x0002
+#define KRB5_LOCKMODE_DONTBLOCK 0x0004
+#define KRB5_LOCKMODE_UNLOCK    0x0008
+
+/*
+ * Begin "preauth.h"
+ *
+ * (Originally written by Glen Machin at Sandia Labs.)
+ */
+/*
+ * Sandia National Laboratories also makes no representations about the
+ * suitability of the modifications, or additions to this software for
+ * any purpose.  It is provided "as is" without express or implied warranty.
+ */
+#ifndef KRB5_PREAUTH__
+#define KRB5_PREAUTH__
+
+typedef struct _krb5_pa_enc_ts {
+    krb5_timestamp      patimestamp;
+    krb5_int32          pausec;
+} krb5_pa_enc_ts;
+
+typedef struct _krb5_pa_for_user {
+    krb5_principal      user;
+    krb5_checksum       cksum;
+    krb5_data           auth_package;
+} krb5_pa_for_user;
+
+typedef struct _krb5_s4u_userid {
+    krb5_int32          nonce;
+    krb5_principal      user;
+    krb5_data           subject_cert;
+    krb5_flags          options;
+} krb5_s4u_userid;
+
+#define KRB5_S4U_OPTS_CHECK_LOGON_HOURS         0x40000000 /* check logon hour restrictions */
+#define KRB5_S4U_OPTS_USE_REPLY_KEY_USAGE       0x20000000 /* sign with usage 27 instead of 26 */
+
+typedef struct _krb5_pa_s4u_x509_user {
+    krb5_s4u_userid     user_id;
+    krb5_checksum       cksum;
+} krb5_pa_s4u_x509_user;
+
+enum {
+    KRB5_FAST_ARMOR_AP_REQUEST = 0x1
+};
+
+typedef struct _krb5_fast_armor {
+    krb5_int32 armor_type;
+    krb5_data armor_value;
+} krb5_fast_armor;
+typedef struct _krb5_fast_armored_req {
+    krb5_magic magic;
+    krb5_fast_armor *armor;
+    krb5_checksum req_checksum;
+    krb5_enc_data enc_part;
+} krb5_fast_armored_req;
+
+typedef struct _krb5_fast_req {
+    krb5_magic magic;
+    krb5_flags fast_options;
+    /* padata from req_body is used*/
+    krb5_kdc_req *req_body;
+} krb5_fast_req;
+
+/* Bits 0-15 are critical in FAST options (RFC 6113 section 7.3). */
+#define UNSUPPORTED_CRITICAL_FAST_OPTIONS   0xbfff0000
+#define KRB5_FAST_OPTION_HIDE_CLIENT_NAMES  0x40000000
+
+typedef struct _krb5_fast_finished {
+    krb5_timestamp timestamp;
+    krb5_int32 usec;
+    krb5_principal client;
+    krb5_checksum ticket_checksum;
+} krb5_fast_finished;
+
+typedef struct _krb5_fast_response {
+    krb5_magic magic;
+    krb5_pa_data **padata;
+    krb5_keyblock *strengthen_key;
+    krb5_fast_finished *finished;
+    krb5_int32 nonce;
+} krb5_fast_response;
+
+typedef struct _krb5_ad_kdcissued {
+    krb5_checksum ad_checksum;
+    krb5_principal i_principal;
+    krb5_authdata **elements;
+} krb5_ad_kdcissued;
+
+typedef struct _krb5_iakerb_header {
+    krb5_data target_realm;
+    krb5_data *cookie;
+} krb5_iakerb_header;
+
+typedef struct _krb5_iakerb_finished {
+    krb5_checksum checksum;
+} krb5_iakerb_finished;
+
+typedef struct _krb5_verifier_mac {
+    krb5_principal princ;
+    krb5_kvno kvno;
+    krb5_enctype enctype;
+    krb5_checksum checksum;
+} krb5_verifier_mac;
+
+/*
+ * AD-CAMMAC's other-verifiers field is a sequence of Verifier, which is an
+ * extensible choice with only one selection, Verifier-MAC.  For the time being
+ * we will represent this field directly as an array of krb5_verifier_mac.
+ * That will have to change if other selections are added.
+ */
+typedef struct _krb5_cammac {
+    krb5_authdata **elements;
+    krb5_verifier_mac *kdc_verifier;
+    krb5_verifier_mac *svc_verifier;
+    krb5_verifier_mac **other_verifiers;
+} krb5_cammac;
+
+void krb5_free_etype_info(krb5_context, krb5_etype_info);
+
+krb5_pa_data *
+krb5int_find_pa_data(krb5_context, krb5_pa_data *const *, krb5_preauthtype);
+/* Does not return a copy; original padata sequence responsible for freeing*/
+
+/* Allocate a pa-data object with uninitialized contents of size len.  If len
+ * is 0, set the contents field to NULL. */
+krb5_error_code
+k5_alloc_pa_data(krb5_preauthtype pa_type, size_t len, krb5_pa_data **out);
+
+/* Free a single pa-data object. */
+void
+k5_free_pa_data_element(krb5_pa_data *pa);
+
+/* Without copying, add single element *pa to *list, reallocating as necessary.
+ * If *list is NULL, allocate a new list.  Set *pa to NULL on success. */
+krb5_error_code
+k5_add_pa_data_element(krb5_pa_data ***list, krb5_pa_data **pa);
+
+/* Without copying, add a pa-data element of type pa_type to *list with the
+ * contents in data.  Set *data to empty_data() on success. */
+krb5_error_code
+k5_add_pa_data_from_data(krb5_pa_data ***list, krb5_preauthtype pa_type,
+                         krb5_data *data);
+
+/* Add an empty pa-data element of type pa_type to *list. */
+krb5_error_code
+k5_add_empty_pa_data(krb5_pa_data ***list, krb5_preauthtype pa_type);
+
+#endif /* KRB5_PREAUTH__ */
+/*
+ * End "preauth.h"
+ */
+
+krb5_error_code
+krb5int_copy_data_contents(krb5_context, const krb5_data *, krb5_data *);
+
+krb5_error_code
+krb5int_copy_data_contents_add0(krb5_context, const krb5_data *, krb5_data *);
+
+void KRB5_CALLCONV
+krb5_free_sam_challenge_2(krb5_context, krb5_sam_challenge_2 *);
+
+void KRB5_CALLCONV
+krb5_free_sam_challenge_2_body(krb5_context, krb5_sam_challenge_2_body *);
+
+void KRB5_CALLCONV
+krb5_free_sam_response_2(krb5_context, krb5_sam_response_2 *);
+
+void KRB5_CALLCONV
+krb5_free_enc_sam_response_enc_2(krb5_context, krb5_enc_sam_response_enc_2 *);
+
+void KRB5_CALLCONV
+krb5_free_sam_challenge_2_contents(krb5_context, krb5_sam_challenge_2 *);
+
+void KRB5_CALLCONV
+krb5_free_sam_challenge_2_body_contents(krb5_context,
+                                        krb5_sam_challenge_2_body *);
+
+void KRB5_CALLCONV
+krb5_free_sam_response_2_contents(krb5_context, krb5_sam_response_2 *);
+
+void KRB5_CALLCONV
+krb5_free_enc_sam_response_enc_2_contents(krb5_context,
+                                          krb5_enc_sam_response_enc_2 * );
+
+void KRB5_CALLCONV
+krb5_free_pa_enc_ts(krb5_context, krb5_pa_enc_ts *);
+
+void KRB5_CALLCONV
+krb5_free_pa_for_user(krb5_context, krb5_pa_for_user *);
+
+void KRB5_CALLCONV
+krb5_free_s4u_userid_contents(krb5_context, krb5_s4u_userid *);
+
+void KRB5_CALLCONV
+krb5_free_pa_s4u_x509_user(krb5_context, krb5_pa_s4u_x509_user *);
+
+void KRB5_CALLCONV
+krb5_free_pa_pac_req(krb5_context, krb5_pa_pac_req * );
+
+void KRB5_CALLCONV krb5_free_fast_armor(krb5_context, krb5_fast_armor *);
+void KRB5_CALLCONV krb5_free_fast_armored_req(krb5_context,
+                                              krb5_fast_armored_req *);
+void KRB5_CALLCONV krb5_free_fast_req(krb5_context, krb5_fast_req *);
+void KRB5_CALLCONV krb5_free_fast_finished(krb5_context, krb5_fast_finished *);
+void KRB5_CALLCONV krb5_free_fast_response(krb5_context, krb5_fast_response *);
+void KRB5_CALLCONV krb5_free_ad_kdcissued(krb5_context, krb5_ad_kdcissued *);
+void KRB5_CALLCONV krb5_free_iakerb_header(krb5_context, krb5_iakerb_header *);
+void KRB5_CALLCONV krb5_free_iakerb_finished(krb5_context,
+                                             krb5_iakerb_finished *);
+void k5_free_algorithm_identifier(krb5_context context,
+                                  krb5_algorithm_identifier *val);
+void k5_free_otp_tokeninfo(krb5_context context, krb5_otp_tokeninfo *val);
+void k5_free_pa_otp_challenge(krb5_context context,
+                              krb5_pa_otp_challenge *val);
+void k5_free_pa_otp_req(krb5_context context, krb5_pa_otp_req *val);
+void k5_free_kkdcp_message(krb5_context context, krb5_kkdcp_message *val);
+void k5_free_cammac(krb5_context context, krb5_cammac *val);
+void k5_free_secure_cookie(krb5_context context, krb5_secure_cookie *val);
+
+krb5_error_code
+k5_unwrap_cammac_svc(krb5_context context, const krb5_authdata *ad,
+                     const krb5_keyblock *key, krb5_authdata ***adata_out);
+krb5_error_code
+k5_authind_decode(const krb5_authdata *ad, krb5_data ***indicators);
+
+/* #include "krb5/wordsize.h" -- comes in through base-defs.h. */
+#include "com_err.h"
+#include "k5-plugin.h"
+
+#include "krb5/authdata_plugin.h"
+
+struct _krb5_authdata_context {
+    krb5_magic magic;
+    int n_modules;
+    struct _krb5_authdata_context_module {
+        krb5_authdatatype ad_type;
+        void *plugin_context;
+        authdata_client_plugin_fini_proc client_fini;
+        krb5_flags flags;
+        krb5plugin_authdata_client_ftable_v0 *ftable;
+        authdata_client_request_init_proc client_req_init;
+        authdata_client_request_fini_proc client_req_fini;
+        const char *name;
+        void *request_context;
+        void **request_context_pp;
+    } *modules;
+    struct plugin_dir_handle plugins;
+};
+
+typedef struct _krb5_authdata_context *krb5_authdata_context;
+
+void
+k5_free_data_ptr_list(krb5_data **list);
+
+void
+k5_zapfree_pa_data(krb5_pa_data **val);
+
+void KRB5_CALLCONV
+krb5int_free_data_list(krb5_context context, krb5_data *data);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_context_init(krb5_context kcontext,
+                           krb5_authdata_context *pcontext);
+
+void KRB5_CALLCONV
+krb5_authdata_context_free(krb5_context kcontext,
+                           krb5_authdata_context context);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_export_authdata(krb5_context kcontext,
+                              krb5_authdata_context context, krb5_flags usage,
+                              krb5_authdata ***pauthdata);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_get_attribute_types(krb5_context kcontext,
+                                  krb5_authdata_context context,
+                                  krb5_data **attrs);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_get_attribute(krb5_context kcontext,
+                            krb5_authdata_context context,
+                            const krb5_data *attribute,
+                            krb5_boolean *authenticated,
+                            krb5_boolean *complete, krb5_data *value,
+                            krb5_data *display_value, int *more);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_set_attribute(krb5_context kcontext,
+                            krb5_authdata_context context,
+                            krb5_boolean complete, const krb5_data *attribute,
+                            const krb5_data *value);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_delete_attribute(krb5_context kcontext,
+                               krb5_authdata_context context,
+                               const krb5_data *attribute);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_import_attributes(krb5_context kcontext,
+                                krb5_authdata_context context,
+                                krb5_flags usage, const krb5_data *attributes);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_export_attributes(krb5_context kcontext,
+                                krb5_authdata_context context,
+                                krb5_flags usage, krb5_data **pattributes);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_export_internal(krb5_context kcontext,
+                              krb5_authdata_context context,
+                              krb5_boolean restrict_authenticated,
+                              const char *module, void **ptr);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_context_copy(krb5_context kcontext, krb5_authdata_context src,
+                           krb5_authdata_context *dst);
+
+krb5_error_code KRB5_CALLCONV
+krb5_authdata_free_internal(krb5_context kcontext,
+                            krb5_authdata_context context, const char *module,
+                            void *ptr);
+
+/*** Plugin framework ***/
+
+/*
+ * This framework can be used to create pluggable interfaces.  Not all existing
+ * pluggable interface use this framework, but new ones should.  A new
+ * pluggable interface entails:
+ *
+ * - An interface ID definition in the list of #defines below.
+ *
+ * - A name in the interface_names array in lib/krb5/krb/plugins.c.
+ *
+ * - An installed public header file in include/krb5.  The public header should
+ *   include <krb5/plugin.h> and should declare a vtable structure for each
+ *   supported major version of the interface.
+ *
+ * - A consumer API implementation, located within the code unit which makes
+ *   use of the pluggable interface.  The consumer API should consist of:
+ *
+ *   . An interface-specific handle type which contains a vtable structure for
+ *     the module (or a union of several such structures, if there are multiple
+ *     supported major versions) and, optionally, resource data bound to the
+ *     handle.
+ *
+ *   . An interface-specific loader function which creates a handle or list of
+ *     handles.  A list of handles would be created if the interface is a
+ *     one-to-many interface where the consumer wants to consult all available
+ *     modules; a single handle would be created for an interface where the
+ *     consumer wants to consult a specific module.  The loader function should
+ *     use k5_plugin_load or k5_plugin_load_all to produce one or a list of
+ *     vtable initializer functions, and should use those functions to fill in
+ *     the vtable structure for the module (if necessary, trying each supported
+ *     major version starting from the most recent).  The loader function can
+ *     also bind resource data into the handle based on caller arguments, if
+ *     appropriate.
+ *
+ *   . For each plugin method, a wrapper function which accepts a krb5_context,
+ *     a plugin handle, and the method arguments.  Wrapper functions should
+ *     invoke the method function contained in the handle's vtable.
+ *
+ * - Possibly, built-in implementations of the interface, also located within
+ *   the code unit which makes use of the interface.  Built-in implementations
+ *   must be registered with k5_plugin_register before the first call to
+ *   k5_plugin_load or k5_plugin_load_all.
+ *
+ * A pluggable interface should have one or more currently supported major
+ * versions, starting at 1.  Each major version should have a current minor
+ * version, also starting at 1.  If new methods are added to a vtable, the
+ * minor version should be incremented and the vtable structure should document
+ * where each minor vtable version ends.  If method signatures for a vtable are
+ * changed, the major version should be incremented.
+ *
+ * Plugin module implementations (either built-in or dynamically loaded) should
+ * define a function named <interfacename>_<modulename>_initvt, matching the
+ * signature of krb5_plugin_initvt_fn as declared in include/krb5/plugin.h.
+ * The initvt function should check the given maj_ver argument against its own
+ * supported major versions, cast the vtable pointer to the appropriate
+ * interface-specific vtable type, and fill in the vtable methods, stopping as
+ * appropriate for the given min_ver.  Memory for the vtable structure is
+ * allocated by the caller, not by the module.
+ *
+ * Dynamic plugin modules are registered with the framework through the
+ * [plugins] section of the profile, as described in the admin documentation
+ * and krb5.conf man page.
+ */
+
+struct plugin_mapping;
+
+/* Holds krb5_context information about each pluggable interface. */
+struct plugin_interface {
+    struct plugin_mapping **modules;
+    krb5_boolean configured;
+};
+
+/* A list of plugin interface IDs.  Make sure to increment
+ * PLUGIN_NUM_INTERFACES when a new interface is added, and add an entry to the
+ * interface_names table in lib/krb5/krb/plugin.c. */
+#define PLUGIN_INTERFACE_PWQUAL      0
+#define PLUGIN_INTERFACE_KADM5_HOOK  1
+#define PLUGIN_INTERFACE_CLPREAUTH   2
+#define PLUGIN_INTERFACE_KDCPREAUTH  3
+#define PLUGIN_INTERFACE_CCSELECT    4
+#define PLUGIN_INTERFACE_LOCALAUTH   5
+#define PLUGIN_INTERFACE_HOSTREALM   6
+#define PLUGIN_INTERFACE_AUDIT       7
+#define PLUGIN_INTERFACE_TLS         8
+#define PLUGIN_INTERFACE_KDCAUTHDATA 9
+#define PLUGIN_INTERFACE_CERTAUTH    10
+#define PLUGIN_INTERFACE_KADM5_AUTH  11
+#define PLUGIN_INTERFACE_KDCPOLICY   12
+#define PLUGIN_NUM_INTERFACES        13
+
+/* Retrieve the plugin module of type interface_id and name modname,
+ * storing the result into module. */
+krb5_error_code
+k5_plugin_load(krb5_context context, int interface_id, const char *modname,
+               krb5_plugin_initvt_fn *module);
+
+/* Retrieve all plugin modules of type interface_id, storing the result
+ * into modules.  Free the result with k5_plugin_free_handles. */
+krb5_error_code
+k5_plugin_load_all(krb5_context context, int interface_id,
+                   krb5_plugin_initvt_fn **modules);
+
+/* Release a module list allocated by k5_plugin_load_all. */
+void
+k5_plugin_free_modules(krb5_context context, krb5_plugin_initvt_fn *modules);
+
+/* Register a plugin module of type interface_id and name modname. */
+krb5_error_code
+k5_plugin_register(krb5_context context, int interface_id, const char *modname,
+                   krb5_plugin_initvt_fn module);
+
+/*
+ * Register a plugin module which is part of the krb5 tree but is built as a
+ * dynamic plugin.  Look for the module in modsubdir relative to the
+ * context->base_plugin_dir.
+ */
+krb5_error_code
+k5_plugin_register_dyn(krb5_context context, int interface_id,
+                       const char *modname, const char *modsubdir);
+
+/* Destroy the module state within context; used by krb5_free_context. */
+void
+k5_plugin_free_context(krb5_context context);
+
+enum dns_canonhost {
+    CANONHOST_FALSE = 0,
+    CANONHOST_TRUE = 1,
+    CANONHOST_FALLBACK = 2
+};
+
+struct _kdb5_dal_handle;        /* private, in kdb5.h */
+typedef struct _kdb5_dal_handle kdb5_dal_handle;
+struct _kdb_log_context;
+typedef struct krb5_preauth_context_st *krb5_preauth_context;
+struct ccselect_module_handle;
+struct localauth_module_handle;
+struct hostrealm_module_handle;
+struct k5_tls_vtable_st;
+struct _krb5_context {
+    krb5_magic      magic;
+    krb5_enctype    *tgs_etypes;
+    struct _krb5_os_context os_context;
+    char            *default_realm;
+    profile_t       profile;
+    kdb5_dal_handle *dal_handle;
+    /* allowable clock skew */
+    krb5_deltat     clockskew;
+    krb5_flags      kdc_default_options;
+    krb5_flags      library_options;
+    krb5_boolean    profile_secure;
+    int             fcc_default_format;
+    krb5_prompt_type *prompt_types;
+    /* Message size above which we'll try TCP first in send-to-kdc
+       type code.  Aside from the 2**16 size limit, we put no
+       absolute limit on the UDP packet size.  */
+    int             udp_pref_limit;
+
+    /* Use the config-file ktypes instead of app-specified?  */
+    krb5_boolean    use_conf_ktypes;
+
+    /* locate_kdc module stuff */
+    struct plugin_dir_handle libkrb5_plugins;
+
+    /* preauth module stuff */
+    krb5_preauth_context preauth_context;
+
+    /* cache module stuff */
+    struct ccselect_module_handle **ccselect_handles;
+
+    /* localauth module stuff */
+    struct localauth_module_handle **localauth_handles;
+
+    /* hostrealm module stuff */
+    struct hostrealm_module_handle **hostrealm_handles;
+
+    /* TLS module vtable (if loaded) */
+    struct k5_tls_vtable_st *tls;
+
+    /* error detail info */
+    struct errinfo err;
+    char *err_fmt;
+
+    /* For Sun iprop code; does this really have to be here?  */
+    struct _kdb_log_context *kdblog_context;
+
+    krb5_boolean allow_weak_crypto;
+    krb5_boolean allow_des3;
+    krb5_boolean allow_rc4;
+    krb5_boolean ignore_acceptor_hostname;
+    krb5_boolean enforce_ok_as_delegate;
+    enum dns_canonhost dns_canonicalize_hostname;
+
+    krb5_trace_callback trace_callback;
+    void *trace_callback_data;
+
+    krb5_pre_send_fn kdc_send_hook;
+    void *kdc_send_hook_data;
+
+    krb5_post_recv_fn kdc_recv_hook;
+    void *kdc_recv_hook_data;
+
+    struct plugin_interface plugins[PLUGIN_NUM_INTERFACES];
+    char *plugin_base_dir;
+};
+
+/* could be used in a table to find an etype and initialize a block */
+
+
+#define KRB5_LIBOPT_SYNC_KDCTIME        0x0001
+
+/* internal message representations */
+
+typedef struct _krb5_safe {
+    krb5_magic magic;
+    krb5_data user_data;                /* user data */
+    krb5_timestamp timestamp;           /* client time, optional */
+    krb5_int32 usec;                    /* microsecond portion of time,
+                                           optional */
+    krb5_ui_4 seq_number;               /* sequence #, optional */
+    krb5_address *s_address;    /* sender address */
+    krb5_address *r_address;    /* recipient address, optional */
+    krb5_checksum *checksum;    /* data integrity checksum */
+} krb5_safe;
+
+typedef struct _krb5_priv {
+    krb5_magic magic;
+    krb5_enc_data enc_part;             /* encrypted part */
+} krb5_priv;
+
+typedef struct _krb5_priv_enc_part {
+    krb5_magic magic;
+    krb5_data user_data;                /* user data */
+    krb5_timestamp timestamp;           /* client time, optional */
+    krb5_int32 usec;                    /* microsecond portion of time, opt. */
+    krb5_ui_4 seq_number;               /* sequence #, optional */
+    krb5_address *s_address;    /* sender address */
+    krb5_address *r_address;    /* recipient address, optional */
+} krb5_priv_enc_part;
+
+void KRB5_CALLCONV krb5_free_safe(krb5_context, krb5_safe *);
+void KRB5_CALLCONV krb5_free_priv(krb5_context, krb5_priv *);
+void KRB5_CALLCONV krb5_free_priv_enc_part(krb5_context, krb5_priv_enc_part *);
+
+/*
+ * Begin "asn1.h"
+ */
+#ifndef KRB5_ASN1__
+#define KRB5_ASN1__
+
+/* ASN.1 encoding knowledge; KEEP IN SYNC WITH ASN.1 defs! */
+/* here we use some knowledge of ASN.1 encodings */
+/*
+  Ticket is APPLICATION 1.
+  Authenticator is APPLICATION 2.
+  AS_REQ is APPLICATION 10.
+  AS_REP is APPLICATION 11.
+  TGS_REQ is APPLICATION 12.
+  TGS_REP is APPLICATION 13.
+  AP_REQ is APPLICATION 14.
+  AP_REP is APPLICATION 15.
+  KRB_SAFE is APPLICATION 20.
+  KRB_PRIV is APPLICATION 21.
+  KRB_CRED is APPLICATION 22.
+  EncASRepPart is APPLICATION 25.
+  EncTGSRepPart is APPLICATION 26.
+  EncAPRepPart is APPLICATION 27.
+  EncKrbPrivPart is APPLICATION 28.
+  EncKrbCredPart is APPLICATION 29.
+  KRB_ERROR is APPLICATION 30.
+*/
+/* allow either constructed or primitive encoding, so check for bit 6
+   set or reset */
+#define krb5int_is_app_tag(dat,tag)                     \
+    ((dat != NULL) && (dat)->length &&                  \
+     ((((dat)->data[0] & ~0x20) == ((tag) | 0x40))))
+#define krb5_is_krb_ticket(dat)               krb5int_is_app_tag(dat, 1)
+#define krb5_is_krb_authenticator(dat)        krb5int_is_app_tag(dat, 2)
+#define krb5_is_as_req(dat)                   krb5int_is_app_tag(dat, 10)
+#define krb5_is_as_rep(dat)                   krb5int_is_app_tag(dat, 11)
+#define krb5_is_tgs_req(dat)                  krb5int_is_app_tag(dat, 12)
+#define krb5_is_tgs_rep(dat)                  krb5int_is_app_tag(dat, 13)
+#define krb5_is_ap_req(dat)                   krb5int_is_app_tag(dat, 14)
+#define krb5_is_ap_rep(dat)                   krb5int_is_app_tag(dat, 15)
+#define krb5_is_krb_safe(dat)                 krb5int_is_app_tag(dat, 20)
+#define krb5_is_krb_priv(dat)                 krb5int_is_app_tag(dat, 21)
+#define krb5_is_krb_cred(dat)                 krb5int_is_app_tag(dat, 22)
+#define krb5_is_krb_enc_as_rep_part(dat)      krb5int_is_app_tag(dat, 25)
+#define krb5_is_krb_enc_tgs_rep_part(dat)     krb5int_is_app_tag(dat, 26)
+#define krb5_is_krb_enc_ap_rep_part(dat)      krb5int_is_app_tag(dat, 27)
+#define krb5_is_krb_enc_krb_priv_part(dat)    krb5int_is_app_tag(dat, 28)
+#define krb5_is_krb_enc_krb_cred_part(dat)    krb5int_is_app_tag(dat, 29)
+#define krb5_is_krb_error(dat)                krb5int_is_app_tag(dat, 30)
+
+/*************************************************************************
+ * Prototypes for krb5_encode.c
+ *************************************************************************/
+
+/*
+  krb5_error_code encode_krb5_structure(const krb5_structure *rep,
+  krb5_data **code);
+  modifies  *code
+  effects   Returns the ASN.1 encoding of *rep in **code.
+  Returns ASN1_MISSING_FIELD if a required field is empty in *rep.
+  Returns ENOMEM if memory runs out.
+*/
+
+krb5_error_code
+encode_krb5_authenticator(const krb5_authenticator *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_ticket(const krb5_ticket *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_enc_tkt_part(const krb5_enc_tkt_part *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_enc_kdc_rep_part(const krb5_enc_kdc_rep_part *rep,
+                             krb5_data **code);
+
+/* yes, the translation is identical to that used for KDC__REP */
+krb5_error_code
+encode_krb5_as_rep(const krb5_kdc_rep *rep, krb5_data **code);
+
+/* yes, the translation is identical to that used for KDC__REP */
+krb5_error_code
+encode_krb5_tgs_rep(const krb5_kdc_rep *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_ap_req(const krb5_ap_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_ap_rep(const krb5_ap_rep *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_ap_rep_enc_part(const krb5_ap_rep_enc_part *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_as_req(const krb5_kdc_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_tgs_req(const krb5_kdc_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_kdc_req_body(const krb5_kdc_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_safe(const krb5_safe *rep, krb5_data **code);
+
+struct krb5_safe_with_body {
+    krb5_safe *safe;
+    krb5_data *body;
+};
+krb5_error_code
+encode_krb5_safe_with_body(const struct krb5_safe_with_body *rep,
+                           krb5_data **code);
+
+krb5_error_code
+encode_krb5_priv(const krb5_priv *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_enc_priv_part(const krb5_priv_enc_part *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_cred(const krb5_cred *rep, krb5_data **code);
+krb5_error_code
+encode_krb5_checksum(const krb5_checksum *, krb5_data **);
+
+krb5_error_code
+encode_krb5_enc_cred_part(const krb5_cred_enc_part *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_error(const krb5_error *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_authdata(krb5_authdata *const *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_padata_sequence(krb5_pa_data *const *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_typed_data(krb5_pa_data *const *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_etype_info(krb5_etype_info_entry *const *, krb5_data **code);
+
+krb5_error_code
+encode_krb5_etype_info2(krb5_etype_info_entry *const *, krb5_data **code);
+
+krb5_error_code
+encode_krb5_pa_enc_ts(const krb5_pa_enc_ts *, krb5_data **);
+
+krb5_error_code
+encode_krb5_sam_challenge_2(const krb5_sam_challenge_2 * , krb5_data **);
+
+krb5_error_code
+encode_krb5_sam_challenge_2_body(const krb5_sam_challenge_2_body *,
+                                 krb5_data **);
+
+krb5_error_code
+encode_krb5_enc_sam_response_enc_2(const krb5_enc_sam_response_enc_2 *,
+                                   krb5_data **);
+
+krb5_error_code
+encode_krb5_sam_response_2(const krb5_sam_response_2 * , krb5_data **);
+
+struct krb5_setpw_req {
+    krb5_principal target;
+    krb5_data password;
+};
+krb5_error_code
+encode_krb5_setpw_req(const struct krb5_setpw_req *rep, krb5_data **code);
+
+krb5_error_code
+encode_krb5_pa_for_user(const krb5_pa_for_user *, krb5_data **);
+
+krb5_error_code
+encode_krb5_s4u_userid(const krb5_s4u_userid *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_s4u_x509_user(const krb5_pa_s4u_x509_user *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_pac_req(const krb5_pa_pac_req *, krb5_data **);
+
+krb5_error_code
+encode_krb5_etype_list(const krb5_etype_list * , krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_fx_fast_request(const krb5_fast_armored_req *, krb5_data **);
+
+krb5_error_code
+encode_krb5_fast_req(const krb5_fast_req *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_fx_fast_reply(const krb5_enc_data *, krb5_data **);
+
+krb5_error_code
+encode_krb5_iakerb_header(const krb5_iakerb_header *, krb5_data **);
+
+krb5_error_code
+encode_krb5_iakerb_finished(const krb5_iakerb_finished *, krb5_data **);
+
+krb5_error_code
+encode_krb5_fast_response(const krb5_fast_response *, krb5_data **);
+
+krb5_error_code
+encode_krb5_ad_kdcissued(const krb5_ad_kdcissued *, krb5_data **);
+
+krb5_error_code
+encode_krb5_otp_tokeninfo(const krb5_otp_tokeninfo *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_otp_challenge(const krb5_pa_otp_challenge *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_otp_req(const krb5_pa_otp_req *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_otp_enc_req(const krb5_data *, krb5_data **);
+
+krb5_error_code
+encode_krb5_kkdcp_message(const krb5_kkdcp_message *, krb5_data **);
+
+krb5_error_code
+encode_krb5_cammac(const krb5_cammac *, krb5_data **);
+
+krb5_error_code
+encode_utf8_strings(krb5_data *const *ut8fstrings, krb5_data **);
+
+krb5_error_code
+encode_krb5_secure_cookie(const krb5_secure_cookie *, krb5_data **);
+
+krb5_error_code
+encode_krb5_pa_pac_options(const krb5_pa_pac_options *, krb5_data **);
+
+/*************************************************************************
+ * End of prototypes for krb5_encode.c
+ *************************************************************************/
+
+krb5_error_code
+decode_krb5_sam_challenge_2(const krb5_data *, krb5_sam_challenge_2 **);
+
+krb5_error_code
+decode_krb5_sam_challenge_2_body(const krb5_data *,
+                                 krb5_sam_challenge_2_body **);
+
+krb5_error_code
+decode_krb5_enc_sam_response_enc_2(const krb5_data *,
+                                   krb5_enc_sam_response_enc_2 **);
+
+krb5_error_code
+decode_krb5_sam_response_2(const krb5_data *, krb5_sam_response_2 **);
+
+
+/*************************************************************************
+ * Prototypes for krb5_decode.c
+ *************************************************************************/
+/*
+  krb5_error_code decode_krb5_structure(const krb5_data *code,
+  krb5_structure **rep);
+
+  requires  Expects **rep to not have been allocated;
+  a new *rep is allocated regardless of the old value.
+  effects   Decodes *code into **rep.
+  Returns ENOMEM if memory is exhausted.
+  Returns asn1 and krb5 errors.
+*/
+
+krb5_error_code
+decode_krb5_authenticator(const krb5_data *code, krb5_authenticator **rep);
+
+krb5_error_code
+decode_krb5_ticket(const krb5_data *code, krb5_ticket **rep);
+
+krb5_error_code
+decode_krb5_encryption_key(const krb5_data *output, krb5_keyblock **rep);
+
+krb5_error_code
+decode_krb5_enc_tkt_part(const krb5_data *output, krb5_enc_tkt_part **rep);
+
+krb5_error_code
+decode_krb5_enc_kdc_rep_part(const krb5_data *output,
+                             krb5_enc_kdc_rep_part **rep);
+
+krb5_error_code
+decode_krb5_as_rep(const krb5_data *output, krb5_kdc_rep **rep);
+
+krb5_error_code
+decode_krb5_tgs_rep(const krb5_data *output, krb5_kdc_rep **rep);
+
+krb5_error_code
+decode_krb5_ap_req(const krb5_data *output, krb5_ap_req **rep);
+
+krb5_error_code
+decode_krb5_ap_rep(const krb5_data *output, krb5_ap_rep **rep);
+
+krb5_error_code
+decode_krb5_ap_rep_enc_part(const krb5_data *output,
+                            krb5_ap_rep_enc_part **rep);
+
+krb5_error_code
+decode_krb5_as_req(const krb5_data *output, krb5_kdc_req **rep);
+
+krb5_error_code
+decode_krb5_tgs_req(const krb5_data *output, krb5_kdc_req **rep);
+
+krb5_error_code
+decode_krb5_kdc_req_body(const krb5_data *output, krb5_kdc_req **rep);
+
+krb5_error_code
+decode_krb5_safe(const krb5_data *output, krb5_safe **rep);
+
+krb5_error_code
+decode_krb5_safe_with_body(const krb5_data *output, krb5_safe **rep,
+                           krb5_data **body);
+
+krb5_error_code
+decode_krb5_priv(const krb5_data *output, krb5_priv **rep);
+
+krb5_error_code
+decode_krb5_enc_priv_part(const krb5_data *output, krb5_priv_enc_part **rep);
+krb5_error_code
+decode_krb5_checksum(const krb5_data *, krb5_checksum **);
+
+krb5_error_code
+decode_krb5_cred(const krb5_data *output, krb5_cred **rep);
+
+krb5_error_code
+decode_krb5_enc_cred_part(const krb5_data *output, krb5_cred_enc_part **rep);
+
+krb5_error_code
+decode_krb5_error(const krb5_data *output, krb5_error **rep);
+
+krb5_error_code
+decode_krb5_authdata(const krb5_data *output, krb5_authdata ***rep);
+
+krb5_error_code
+decode_krb5_padata_sequence(const krb5_data *output, krb5_pa_data ***rep);
+
+krb5_error_code
+decode_krb5_typed_data(const krb5_data *, krb5_pa_data ***);
+
+krb5_error_code
+decode_krb5_etype_info(const krb5_data *output, krb5_etype_info_entry ***rep);
+
+krb5_error_code
+decode_krb5_etype_info2(const krb5_data *output, krb5_etype_info_entry ***rep);
+
+krb5_error_code
+decode_krb5_enc_data(const krb5_data *output, krb5_enc_data **rep);
+
+krb5_error_code
+decode_krb5_pa_enc_ts(const krb5_data *output, krb5_pa_enc_ts **rep);
+
+krb5_error_code
+decode_krb5_setpw_req(const krb5_data *, krb5_data **, krb5_principal *);
+
+krb5_error_code
+decode_krb5_pa_for_user(const krb5_data *, krb5_pa_for_user **);
+
+krb5_error_code
+decode_krb5_pa_s4u_x509_user(const krb5_data *, krb5_pa_s4u_x509_user **);
+
+krb5_error_code
+decode_krb5_pa_pac_req(const krb5_data *, krb5_pa_pac_req **);
+
+krb5_error_code
+decode_krb5_etype_list(const krb5_data *, krb5_etype_list **);
+
+krb5_error_code
+decode_krb5_pa_fx_fast_request(const krb5_data *, krb5_fast_armored_req **);
+
+krb5_error_code
+decode_krb5_fast_req(const krb5_data *, krb5_fast_req **);
+
+krb5_error_code
+decode_krb5_pa_fx_fast_reply(const krb5_data *, krb5_enc_data **);
+
+krb5_error_code
+decode_krb5_fast_response(const krb5_data *, krb5_fast_response **);
+
+krb5_error_code
+decode_krb5_ad_kdcissued(const krb5_data *, krb5_ad_kdcissued **);
+
+krb5_error_code
+decode_krb5_iakerb_header(const krb5_data *, krb5_iakerb_header **);
+
+krb5_error_code
+decode_krb5_iakerb_finished(const krb5_data *, krb5_iakerb_finished **);
+
+krb5_error_code
+decode_krb5_otp_tokeninfo(const krb5_data *, krb5_otp_tokeninfo **);
+
+krb5_error_code
+decode_krb5_pa_otp_challenge(const krb5_data *, krb5_pa_otp_challenge **);
+
+krb5_error_code
+decode_krb5_pa_otp_req(const krb5_data *, krb5_pa_otp_req **);
+
+krb5_error_code
+decode_krb5_pa_otp_enc_req(const krb5_data *, krb5_data **);
+
+krb5_error_code
+decode_krb5_kkdcp_message(const krb5_data *, krb5_kkdcp_message **);
+
+krb5_error_code
+decode_krb5_cammac(const krb5_data *, krb5_cammac **);
+
+krb5_error_code
+decode_utf8_strings(const krb5_data *, krb5_data ***);
+
+krb5_error_code
+decode_krb5_secure_cookie(const krb5_data *, krb5_secure_cookie **);
+
+krb5_error_code
+decode_krb5_pa_pac_options(const krb5_data *, krb5_pa_pac_options **);
+
+struct _krb5_key_data;          /* kdb.h */
+
+struct ldap_seqof_key_data {
+    krb5_int32 mkvno;           /* Master key version number */
+    krb5_ui_2 kvno;             /* kvno of key_data elements (all the same) */
+    struct _krb5_key_data *key_data;
+    krb5_int16 n_key_data;
+};
+typedef struct ldap_seqof_key_data ldap_seqof_key_data;
+
+krb5_error_code
+krb5int_ldap_encode_sequence_of_keys(const ldap_seqof_key_data *val,
+                                     krb5_data **code);
+
+krb5_error_code
+krb5int_ldap_decode_sequence_of_keys(const krb5_data *in,
+                                     ldap_seqof_key_data **rep);
+
+/*************************************************************************
+ * End of prototypes for krb5_decode.c
+ *************************************************************************/
+
+#endif /* KRB5_ASN1__ */
+/*
+ * End "asn1.h"
+ */
+
+
+/*
+ * Internal krb5 library routines
+ */
+krb5_error_code
+krb5_encrypt_tkt_part(krb5_context, const krb5_keyblock *, krb5_ticket *);
+
+krb5_error_code
+krb5_encode_kdc_rep(krb5_context, krb5_msgtype, const krb5_enc_kdc_rep_part *,
+                    int using_subkey, const krb5_keyblock *, krb5_kdc_rep *,
+                    krb5_data ** );
+
+/* Return true if s is non-empty and composed solely of digits. */
+krb5_boolean
+k5_is_string_numeric(const char *s);
+
+krb5_error_code
+k5_parse_host_string(const char *address, int default_port, char **host_out,
+                     int *port_out);
+
+krb5_error_code
+k5_size_authdata_context(krb5_context kcontext, krb5_authdata_context context,
+                         size_t *sizep);
+
+krb5_error_code
+k5_externalize_authdata_context(krb5_context kcontext,
+                                krb5_authdata_context context,
+                                krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_authdata_context(krb5_context kcontext,
+                                krb5_authdata_context *ptr,
+                                krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_auth_context(krb5_auth_context auth_context, size_t *sizep);
+
+krb5_error_code
+k5_externalize_auth_context(krb5_auth_context auth_context,
+                            krb5_octet **buffer, size_t *lenremain);
+krb5_error_code
+k5_internalize_auth_context(krb5_auth_context *argp,
+                            krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_authdata(krb5_authdata *authdata, size_t *sizep);
+
+krb5_error_code
+k5_externalize_authdata(krb5_authdata *authdata,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_authdata(krb5_authdata **authdata,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_address(krb5_address *address, size_t *sizep);
+
+krb5_error_code
+k5_externalize_address(krb5_address *address,
+                       krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_address(krb5_address **argp,
+                       krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_authenticator(krb5_authenticator *authenticator, size_t *sizep);
+
+krb5_error_code
+k5_externalize_authenticator(krb5_authenticator *authenticator,
+                             krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_authenticator(krb5_authenticator **argp,
+                             krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_checksum(krb5_checksum *checksum, size_t *sizep);
+
+krb5_error_code
+k5_externalize_checksum(krb5_checksum *checksum,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_checksum(krb5_checksum **argp,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_context(krb5_context context, size_t *sizep);
+
+krb5_error_code
+k5_externalize_context(krb5_context context,
+                       krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_context(krb5_context *argp,
+                       krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_keyblock(krb5_keyblock *keyblock, size_t *sizep);
+
+krb5_error_code
+k5_externalize_keyblock(krb5_keyblock *keyblock,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_keyblock(krb5_keyblock **argp,
+                        krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_size_principal(krb5_principal principal, size_t *sizep);
+
+krb5_error_code
+k5_externalize_principal(krb5_principal principal,
+                         krb5_octet **buffer, size_t *lenremain);
+
+krb5_error_code
+k5_internalize_principal(krb5_principal *argp,
+                         krb5_octet **buffer, size_t *lenremain);
+
+/*
+ * Initialization routines.
+ */
+
+/* [De]serialize 4-byte integer */
+krb5_error_code KRB5_CALLCONV
+krb5_ser_pack_int32(krb5_int32, krb5_octet **, size_t *);
+
+krb5_error_code KRB5_CALLCONV
+krb5_ser_unpack_int32(krb5_int32 *, krb5_octet **, size_t *);
+
+/* [De]serialize 8-byte integer */
+krb5_error_code KRB5_CALLCONV
+krb5_ser_pack_int64(int64_t, krb5_octet **, size_t *);
+
+krb5_error_code KRB5_CALLCONV
+krb5_ser_unpack_int64(int64_t *, krb5_octet **, size_t *);
+
+/* [De]serialize byte string */
+krb5_error_code KRB5_CALLCONV
+krb5_ser_pack_bytes(krb5_octet *, size_t, krb5_octet **, size_t *);
+
+krb5_error_code KRB5_CALLCONV
+krb5_ser_unpack_bytes(krb5_octet *, size_t, krb5_octet **, size_t *);
+
+krb5_error_code KRB5_CALLCONV
+krb5int_cc_default(krb5_context, krb5_ccache *);
+
+krb5_error_code
+k5_cc_store_primary_cred(krb5_context, krb5_ccache, krb5_creds *);
+
+/* Fill in the buffer with random alphanumeric data. */
+krb5_error_code
+krb5int_random_string(krb5_context, char *string, unsigned int length);
+
+/* value to use when requesting a keytab entry and KVNO doesn't matter */
+#define IGNORE_VNO 0
+/* value to use when requesting a keytab entry and enctype doesn't matter */
+#define IGNORE_ENCTYPE 0
+
+/* To keep happy libraries which are (for now) accessing internal stuff */
+
+/* Make sure to increment by one when changing the struct */
+#define KRB5INT_ACCESS_STRUCT_VERSION 23
+
+typedef struct _krb5int_access {
+    krb5_error_code (*auth_con_get_subkey_enctype)(krb5_context,
+                                                   krb5_auth_context,
+                                                   krb5_enctype *);
+
+    krb5_error_code (*mandatory_cksumtype)(krb5_context, krb5_enctype,
+                                           krb5_cksumtype *);
+    krb5_error_code (KRB5_CALLCONV *ser_pack_int64)(int64_t, krb5_octet **,
+                                                    size_t *);
+    krb5_error_code (KRB5_CALLCONV *ser_unpack_int64)(int64_t *, krb5_octet **,
+                                                      size_t *);
+
+    /* Used for KDB LDAP back end.  */
+    krb5_error_code
+    (*asn1_ldap_encode_sequence_of_keys)(const ldap_seqof_key_data *val,
+                                         krb5_data **code);
+
+    krb5_error_code
+    (*asn1_ldap_decode_sequence_of_keys)(const krb5_data *in,
+                                         ldap_seqof_key_data **);
+
+    /*
+     * pkinit asn.1 encode/decode functions
+     */
+    krb5_error_code
+    (*encode_krb5_auth_pack)(const krb5_auth_pack *rep, krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_kdc_dh_key_info)(const krb5_kdc_dh_key_info *rep,
+                                   krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_pa_pk_as_rep)(const krb5_pa_pk_as_rep *rep,
+                                krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_pa_pk_as_req)(const krb5_pa_pk_as_req *rep,
+                                krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_reply_key_pack)(const krb5_reply_key_pack *,
+                                  krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_td_dh_parameters)(krb5_algorithm_identifier *const *,
+                                    krb5_data **code);
+
+    krb5_error_code
+    (*encode_krb5_td_trusted_certifiers)(krb5_external_principal_identifier *
+                                         const *, krb5_data **code);
+
+    krb5_error_code
+    (*decode_krb5_auth_pack)(const krb5_data *, krb5_auth_pack **);
+
+    krb5_error_code
+    (*decode_krb5_pa_pk_as_req)(const krb5_data *, krb5_pa_pk_as_req **);
+
+    krb5_error_code
+    (*decode_krb5_pa_pk_as_rep)(const krb5_data *, krb5_pa_pk_as_rep **);
+
+    krb5_error_code
+    (*decode_krb5_kdc_dh_key_info)(const krb5_data *, krb5_kdc_dh_key_info **);
+
+    krb5_error_code
+    (*decode_krb5_principal_name)(const krb5_data *, krb5_principal_data **);
+
+    krb5_error_code
+    (*decode_krb5_reply_key_pack)(const krb5_data *, krb5_reply_key_pack **);
+
+    krb5_error_code
+    (*decode_krb5_td_dh_parameters)(const krb5_data *,
+                                    krb5_algorithm_identifier ***);
+
+    krb5_error_code
+    (*decode_krb5_td_trusted_certifiers)(const krb5_data *,
+                                         krb5_external_principal_identifier
+                                         ***);
+
+    krb5_error_code
+    (*encode_krb5_kdc_req_body)(const krb5_kdc_req *rep, krb5_data **code);
+
+    void
+    (KRB5_CALLCONV *free_kdc_req)(krb5_context, krb5_kdc_req * );
+    void
+    (*set_prompt_types)(krb5_context, krb5_prompt_type *);
+} krb5int_access;
+
+#define KRB5INT_ACCESS_VERSION                                          \
+    (((krb5_int32)((sizeof(krb5int_access) & 0xFFFF) |                  \
+                   (KRB5INT_ACCESS_STRUCT_VERSION << 16))) & 0xFFFFFFFF)
+
+krb5_error_code KRB5_CALLCONV
+krb5int_accessor(krb5int_access*, krb5_int32);
+
+krb5_error_code KRB5_CALLCONV
+krb5int_cc_user_set_default_name(krb5_context context, const char *name);
+
+krb5_error_code k5_rc_default(krb5_context context, krb5_rcache *rc_out);
+krb5_error_code k5_rc_resolve(krb5_context context, const char *name,
+                              krb5_rcache *rc_out);
+void k5_rc_close(krb5_context context, krb5_rcache rc);
+krb5_error_code k5_rc_store(krb5_context context, krb5_rcache rc,
+                            const krb5_enc_data *authenticator);
+const char *k5_rc_get_name(krb5_context context, krb5_rcache rc);
+
+/* Set *tag_out to the integrity tag of *enc.  (Does not allocate memory;
+ * returned buffer is a subrange of *ctext.) */
+krb5_error_code
+k5_rc_tag_from_ciphertext(krb5_context context, const krb5_enc_data *enc,
+                          krb5_data *tag_out);
+
+/*
+ * This structure was exposed and used in macros in krb5 1.2, so do not
+ * change its ABI.
+ */
+typedef struct _krb5_kt_ops {
+    krb5_magic magic;
+    char *prefix;
+
+    /* routines always present */
+    krb5_error_code (KRB5_CALLCONV *resolve)(krb5_context, const char *,
+                                             krb5_keytab *);
+    krb5_error_code (KRB5_CALLCONV *get_name)(krb5_context, krb5_keytab,
+                                              char *, unsigned int);
+    krb5_error_code (KRB5_CALLCONV *close)(krb5_context, krb5_keytab);
+    krb5_error_code (KRB5_CALLCONV *get)(krb5_context, krb5_keytab,
+                                         krb5_const_principal, krb5_kvno,
+                                         krb5_enctype, krb5_keytab_entry *);
+    krb5_error_code (KRB5_CALLCONV *start_seq_get)(krb5_context, krb5_keytab,
+                                                   krb5_kt_cursor *);
+    krb5_error_code (KRB5_CALLCONV *get_next)(krb5_context, krb5_keytab,
+                                              krb5_keytab_entry *,
+                                              krb5_kt_cursor *);
+    krb5_error_code (KRB5_CALLCONV *end_get)(krb5_context, krb5_keytab,
+                                             krb5_kt_cursor *);
+    /* routines to be included on extended version (write routines) */
+    krb5_error_code (KRB5_CALLCONV *add)(krb5_context, krb5_keytab,
+                                         krb5_keytab_entry *);
+    krb5_error_code (KRB5_CALLCONV *remove)(krb5_context, krb5_keytab,
+                                            krb5_keytab_entry *);
+} krb5_kt_ops;
+
+/* Not sure it's ready for exposure just yet.  */
+extern krb5_error_code
+krb5int_c_mandatory_cksumtype(krb5_context, krb5_enctype, krb5_cksumtype *);
+
+/*
+ * Referral definitions and subfunctions.
+ */
+#define        KRB5_REFERRAL_MAXHOPS    10
+
+struct _krb5_kt {       /* should move into k5-int.h */
+    krb5_magic magic;
+    const struct _krb5_kt_ops *ops;
+    krb5_pointer data;
+};
+
+krb5_error_code krb5_get_default_in_tkt_ktypes(krb5_context, krb5_enctype **);
+
+krb5_error_code KRB5_CALLCONV
+krb5_get_tgs_ktypes(krb5_context, krb5_const_principal, krb5_enctype **);
+
+krb5_boolean krb5_is_permitted_enctype(krb5_context, krb5_enctype);
+
+krb5_boolean KRB5_CALLCONV krb5int_c_weak_enctype(krb5_enctype);
+krb5_boolean KRB5_CALLCONV krb5int_c_deprecated_enctype(krb5_enctype);
+krb5_error_code k5_enctype_to_ssf(krb5_enctype enctype, unsigned int *ssf_out);
+
+krb5_error_code krb5_kdc_rep_decrypt_proc(krb5_context, const krb5_keyblock *,
+                                          krb5_const_pointer, krb5_kdc_rep *);
+krb5_error_code KRB5_CALLCONV krb5_decrypt_tkt_part(krb5_context,
+                                                    const krb5_keyblock *,
+                                                    krb5_ticket * );
+
+krb5_error_code krb5_get_cred_via_tkt(krb5_context, krb5_creds *, krb5_flags,
+                                      krb5_address *const *, krb5_creds *,
+                                      krb5_creds **);
+
+krb5_error_code KRB5_CALLCONV krb5_copy_addr(krb5_context,
+                                             const krb5_address *,
+                                             krb5_address **);
+
+void krb5_init_ets(krb5_context);
+void krb5_free_ets(krb5_context);
+krb5_error_code krb5_generate_subkey(krb5_context, const krb5_keyblock *,
+                                     krb5_keyblock **);
+krb5_error_code krb5_generate_subkey_extended(krb5_context,
+                                              const krb5_keyblock *,
+                                              krb5_enctype, krb5_keyblock **);
+krb5_error_code krb5_generate_seq_number(krb5_context, const krb5_keyblock *,
+                                         krb5_ui_4 *);
+
+krb5_error_code KRB5_CALLCONV krb5_kt_register(krb5_context,
+                                               const struct _krb5_kt_ops *);
+
+krb5_error_code k5_kt_get_principal(krb5_context context, krb5_keytab keytab,
+                                    krb5_principal *princ_out);
+
+krb5_error_code k5_kt_have_match(krb5_context context, krb5_keytab keytab,
+                                 krb5_principal mprinc);
+
+krb5_error_code krb5_principal2salt_norealm(krb5_context, krb5_const_principal,
+                                            krb5_data *);
+
+unsigned int KRB5_CALLCONV krb5_get_notification_message(void);
+
+/* chk_trans.c */
+krb5_error_code krb5_check_transited_list(krb5_context, const krb5_data *trans,
+                                          const krb5_data *realm1,
+                                          const krb5_data *realm2);
+
+/* free_rtree.c */
+void krb5_free_realm_tree(krb5_context, krb5_principal *);
+
+void KRB5_CALLCONV krb5_free_authenticator_contents(krb5_context,
+                                                    krb5_authenticator *);
+
+void KRB5_CALLCONV krb5_free_address(krb5_context, krb5_address *);
+
+void KRB5_CALLCONV krb5_free_enc_tkt_part(krb5_context, krb5_enc_tkt_part *);
+
+void KRB5_CALLCONV krb5_free_tickets(krb5_context, krb5_ticket **);
+void KRB5_CALLCONV krb5_free_kdc_req(krb5_context, krb5_kdc_req *);
+void KRB5_CALLCONV krb5_free_kdc_rep(krb5_context, krb5_kdc_rep *);
+void KRB5_CALLCONV krb5_free_last_req(krb5_context, krb5_last_req_entry **);
+void KRB5_CALLCONV krb5_free_enc_kdc_rep_part(krb5_context,
+                                              krb5_enc_kdc_rep_part *);
+void KRB5_CALLCONV krb5_free_ap_req(krb5_context, krb5_ap_req *);
+void KRB5_CALLCONV krb5_free_ap_rep(krb5_context, krb5_ap_rep *);
+void KRB5_CALLCONV krb5_free_cred(krb5_context, krb5_cred *);
+void KRB5_CALLCONV krb5_free_cred_enc_part(krb5_context, krb5_cred_enc_part *);
+void KRB5_CALLCONV krb5_free_pa_data(krb5_context, krb5_pa_data **);
+void KRB5_CALLCONV krb5_free_tkt_authent(krb5_context, krb5_tkt_authent *);
+void KRB5_CALLCONV krb5_free_enc_data(krb5_context, krb5_enc_data *);
+krb5_error_code krb5_set_config_files(krb5_context, const char **);
+
+krb5_error_code KRB5_CALLCONV krb5_get_default_config_files(char ***filenames);
+
+void KRB5_CALLCONV krb5_free_config_files(char **filenames);
+
+krb5_error_code krb5_rd_req_decoded(krb5_context, krb5_auth_context *,
+                                    const krb5_ap_req *, krb5_const_principal,
+                                    krb5_keytab, krb5_flags *, krb5_ticket **);
+
+krb5_error_code krb5_rd_req_decoded_anyflag(krb5_context, krb5_auth_context *,
+                                            const krb5_ap_req *,
+                                            krb5_const_principal, krb5_keytab,
+                                            krb5_flags *, krb5_ticket **);
+
+krb5_error_code KRB5_CALLCONV
+krb5_cc_register(krb5_context, const krb5_cc_ops *, krb5_boolean );
+
+krb5_error_code krb5_walk_realm_tree(krb5_context, const krb5_data *,
+                                     const krb5_data *, krb5_principal **,
+                                     int);
+
+krb5_error_code
+krb5_auth_con_set_safe_cksumtype(krb5_context, krb5_auth_context,
+                                 krb5_cksumtype);
+
+krb5_error_code krb5_auth_con_setivector(krb5_context, krb5_auth_context,
+                                         krb5_pointer);
+
+krb5_error_code krb5_auth_con_getivector(krb5_context, krb5_auth_context,
+                                         krb5_pointer *);
+
+krb5_error_code krb5_auth_con_setpermetypes(krb5_context, krb5_auth_context,
+                                            const krb5_enctype *);
+
+krb5_error_code krb5_auth_con_getpermetypes(krb5_context, krb5_auth_context,
+                                            krb5_enctype **);
+
+krb5_error_code krb5_auth_con_get_subkey_enctype(krb5_context context,
+                                                 krb5_auth_context,
+                                                 krb5_enctype *);
+
+krb5_error_code
+krb5_auth_con_get_authdata_context(krb5_context context,
+                                   krb5_auth_context auth_context,
+                                   krb5_authdata_context *ad_context);
+
+krb5_error_code
+krb5_auth_con_set_authdata_context(krb5_context context,
+                                   krb5_auth_context auth_context,
+                                   krb5_authdata_context ad_context);
+
+krb5_error_code krb5_read_message(krb5_context, krb5_pointer, krb5_data *);
+krb5_error_code krb5_write_message(krb5_context, krb5_pointer, krb5_data *);
+int krb5_net_read(krb5_context, int , char *, int);
+int krb5_net_write(krb5_context, int , const char *, int);
+
+krb5_error_code KRB5_CALLCONV krb5_get_realm_domain(krb5_context,
+                                                    const char *, char ** );
+
+krb5_error_code krb5_gen_portaddr(krb5_context, const krb5_address *,
+                                  krb5_const_pointer, krb5_address **);
+
+krb5_error_code krb5_gen_replay_name(krb5_context, const krb5_address *,
+                                     const char *, char **);
+krb5_error_code krb5_make_fulladdr(krb5_context, krb5_address *,
+                                   krb5_address *, krb5_address *);
+
+krb5_error_code krb5_set_debugging_time(krb5_context, krb5_timestamp,
+                                        krb5_int32);
+krb5_error_code krb5_use_natural_time(krb5_context);
+krb5_error_code krb5_set_time_offsets(krb5_context, krb5_timestamp,
+                                      krb5_int32);
+
+/* Some data comparison and conversion functions.  */
+static inline int
+data_eq(krb5_data d1, krb5_data d2)
+{
+    return (d1.length == d2.length && (d1.length == 0 ||
+                                       !memcmp(d1.data, d2.data, d1.length)));
+}
+
+static inline int
+data_eq_string (krb5_data d, const char *s)
+{
+    return (d.length == strlen(s) && (d.length == 0 ||
+                                      !memcmp(d.data, s, d.length)));
+}
+
+static inline krb5_data
+make_data(void *data, unsigned int len)
+{
+    krb5_data d;
+
+    d.magic = KV5M_DATA;
+    d.data = (char *) data;
+    d.length = len;
+    return d;
+}
+
+static inline krb5_data
+empty_data()
+{
+    return make_data(NULL, 0);
+}
+
+static inline krb5_data
+string2data(char *str)
+{
+    return make_data(str, strlen(str));
+}
+
+static inline krb5_error_code
+alloc_data(krb5_data *data, unsigned int len)
+{
+    /* Allocate at least one byte since zero-byte allocs may return NULL. */
+    char *ptr = (char *) calloc((len > 0) ? len : 1, 1);
+
+    if (ptr == NULL)
+        return ENOMEM;
+    data->magic = KV5M_DATA;
+    data->data = ptr;
+    data->length = len;
+    return 0;
+}
+
+static inline int
+authdata_eq(krb5_authdata a1, krb5_authdata a2)
+{
+    return (a1.ad_type == a2.ad_type && a1.length == a2.length &&
+            (a1.length == 0 || !memcmp(a1.contents, a2.contents, a1.length)));
+}
+
+/* Allocate zeroed memory; set *code to 0 on success or ENOMEM on failure. */
+static inline void *
+k5calloc(size_t nmemb, size_t size, krb5_error_code *code)
+{
+    void *ptr;
+
+    /* Allocate at least one byte since zero-byte allocs may return NULL. */
+    ptr = calloc(nmemb ? nmemb : 1, size ? size : 1);
+    *code = (ptr == NULL) ? ENOMEM : 0;
+    return ptr;
+}
+
+/* Allocate zeroed memory; set *code to 0 on success or ENOMEM on failure. */
+static inline void *
+k5alloc(size_t size, krb5_error_code *code)
+{
+    return k5calloc(1, size, code);
+}
+
+/* Return a copy of the len bytes of memory at in; set *code to 0 or ENOMEM. */
+static inline void *
+k5memdup(const void *in, size_t len, krb5_error_code *code)
+{
+    void *ptr = k5alloc(len, code);
+
+    if (ptr != NULL && len > 0)
+        memcpy(ptr, in, len);
+    return ptr;
+}
+
+/* Like k5memdup, but add a final null byte. */
+static inline void *
+k5memdup0(const void *in, size_t len, krb5_error_code *code)
+{
+    void *ptr = k5alloc(len + 1, code);
+
+    if (ptr != NULL && len > 0)
+        memcpy(ptr, in, len);
+    return ptr;
+}
+
+/* Convert a krb5_timestamp to a time_t value, treating the negative range of
+ * krb5_timestamp as times between 2038 and 2106 (if time_t is 64-bit). */
+static inline time_t
+ts2tt(krb5_timestamp timestamp)
+{
+    return (time_t)(uint32_t)timestamp;
+}
+
+/* Return the delta between two timestamps (a - b) as a signed 32-bit value,
+ * without relying on undefined behavior. */
+static inline krb5_deltat
+ts_delta(krb5_timestamp a, krb5_timestamp b)
+{
+    return (krb5_deltat)((uint32_t)a - (uint32_t)b);
+}
+
+/* Return (end - start) as an unsigned 32-bit value, or 0 if start > end. */
+static inline uint32_t
+ts_interval(krb5_timestamp start, krb5_timestamp end)
+{
+    if ((uint32_t)start > (uint32_t)end)
+        return 0;
+    return (uint32_t)end - (uint32_t)start;
+}
+
+/* Increment a timestamp by a signed 32-bit interval, without relying on
+ * undefined behavior. */
+static inline krb5_timestamp
+ts_incr(krb5_timestamp ts, krb5_deltat delta)
+{
+    return (krb5_timestamp)((uint32_t)ts + (uint32_t)delta);
+}
+
+/* Return true if a comes after b. */
+static inline krb5_boolean
+ts_after(krb5_timestamp a, krb5_timestamp b)
+{
+    return (uint32_t)a > (uint32_t)b;
+}
+
+/* Return true if a and b are within d seconds. */
+static inline krb5_boolean
+ts_within(krb5_timestamp a, krb5_timestamp b, krb5_deltat d)
+{
+    return !ts_after(a, ts_incr(b, d)) && !ts_after(b, ts_incr(a, d));
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_get_credentials_for_user(krb5_context context, krb5_flags options,
+                              krb5_ccache ccache,
+                              krb5_creds *in_creds,
+                              krb5_data *cert,
+                              krb5_creds **out_creds);
+
+krb5_error_code KRB5_CALLCONV
+krb5_get_credentials_for_proxy(krb5_context context,
+                               krb5_flags options,
+                               krb5_ccache ccache,
+                               krb5_creds *in_creds,
+                               krb5_ticket *evidence_tkt,
+                               krb5_creds **out_creds);
+
+krb5_error_code KRB5_CALLCONV
+krb5int_get_authdata_containee_types(krb5_context context,
+                                     const krb5_authdata *container,
+                                     unsigned int *nad_types,
+                                     krb5_authdatatype **ad_types);
+
+krb5_error_code krb5int_parse_enctype_list(krb5_context context,
+                                           const char *profkey, char *profstr,
+                                           krb5_enctype *default_list,
+                                           krb5_enctype **result);
+
+krb5_boolean k5_etypes_contains(const krb5_enctype *list, krb5_enctype etype);
+
+void k5_change_error_message_code(krb5_context ctx, krb5_error_code oldcode,
+                                  krb5_error_code newcode);
+
+/* Define shorter internal names for setting error messages. */
+#define k5_setmsg krb5_set_error_message
+#define k5_prependmsg krb5_prepend_error_message
+#define k5_wrapmsg krb5_wrap_error_message
+
+/*
+ * Like krb5_principal_compare(), but with canonicalization of sname if
+ * fallback is enabled.  This function should be avoided if multiple matches
+ * are required, since repeated canonicalization is inefficient.
+ */
+krb5_boolean
+k5_sname_compare(krb5_context context, krb5_const_principal sname,
+                 krb5_const_principal princ);
+
+#endif /* _KRB5_INT_H */

--- a/auth/kinit_client/k5-platform.h
+++ b/auth/kinit_client/k5-platform.h
@@ -1,0 +1,1151 @@
+/* -*- mode: c; indent-tabs-mode: nil -*- */
+/* include/k5-platform.h */
+/*
+ * Copyright 2003, 2004, 2005, 2007, 2008, 2009 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/*
+ * Some platform-dependent definitions to sync up the C support level.
+ * Some to a C99-ish level, some related utility code.
+ *
+ * Currently:
+ * + [u]int{8,16,32}_t types
+ * + 64-bit types and load/store code
+ * + SIZE_MAX
+ * + shared library init/fini hooks
+ * + consistent getpwnam/getpwuid interfaces
+ * + va_copy fudged if not provided
+ * + strlcpy/strlcat
+ * + fnmatch
+ * + [v]asprintf
+ * + strerror_r
+ * + mkstemp
+ * + zap (support function and macro)
+ * + constant time memory comparison
+ * + path manipulation
+ * + _, N_, dgettext, bindtextdomain (for localization)
+ * + getopt_long
+ * + secure_getenv
+ * + fetching filenames from a directory
+ */
+
+#ifndef K5_PLATFORM_H
+#define K5_PLATFORM_H
+
+#include "autoconf.h"
+#include <assert.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#ifdef HAVE_FNMATCH_H
+#include <fnmatch.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef _WIN32
+#define CAN_COPY_VA_LIST
+#endif
+
+/* This attribute prevents unused function warnings in gcc and clang. */
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
+#if defined(macintosh) || (defined(__MACH__) && defined(__APPLE__))
+#include <TargetConditionals.h>
+#endif
+
+/* Initialization and finalization function support for libraries.
+
+   At top level, before the functions are defined or even declared:
+   MAKE_INIT_FUNCTION(init_fn);
+   MAKE_FINI_FUNCTION(fini_fn);
+   Then:
+   int init_fn(void) { ... }
+   void fini_fn(void) { if (INITIALIZER_RAN(init_fn)) ... }
+   In code, in the same file:
+   err = CALL_INIT_FUNCTION(init_fn);
+
+   To trigger or verify the initializer invocation from another file,
+   a helper function must be created.
+
+   This model handles both the load-time execution (Windows) and
+   delayed execution (pthread_once) approaches, and should be able to
+   guarantee in both cases that the init function is run once, in one
+   thread, before other stuff in the library is done; furthermore, the
+   finalization code should only run if the initialization code did.
+   (Maybe I could've made the "if INITIALIZER_RAN" test implicit, via
+   another function hidden in macros, but this is hairy enough
+   already.)
+
+   The init_fn and fini_fn names should be chosen such that any
+   exported names staring with those names, and optionally followed by
+   additional characters, fits in with any namespace constraints on
+   the library in question.
+
+
+   There's also PROGRAM_EXITING() currently always defined as zero.
+   If there's some trivial way to find out if the fini function is
+   being called because the program that the library is linked into is
+   exiting, we can just skip all the work because the resources are
+   about to be freed up anyways.  Generally this is likely to be the
+   same as distinguishing whether the library was loaded dynamically
+   while the program was running, or loaded as part of program
+   startup.  On most platforms, I don't think we can distinguish these
+   cases easily, and it's probably not worth expending any significant
+   effort.  (Note in particular that atexit() won't do, because if the
+   library is explicitly loaded and unloaded, it would have to be able
+   to deregister the atexit callback function.  Also, the system limit
+   on atexit callbacks may be small.)
+
+
+   Implementation outline:
+
+   Windows: MAKE_FINI_FUNCTION creates a symbol with a magic name that
+   is sought at library build time, and code is added to invoke the
+   function when the library is unloaded.  MAKE_INIT_FUNCTION does
+   likewise, but the function is invoked when the library is loaded,
+   and an extra variable is declared to hold an error code and a "yes
+   the initializer ran" flag.  CALL_INIT_FUNCTION blows up if the flag
+   isn't set, otherwise returns the error code.
+
+   UNIX: MAKE_INIT_FUNCTION creates and initializes a variable with a
+   name derived from the function name, containing a k5_once_t
+   (pthread_once_t or int), an error code, and a pointer to the
+   function.  The function itself is declared static, but the
+   associated variable has external linkage.  CALL_INIT_FUNCTION
+   ensures thath the function is called exactly once (pthread_once or
+   just check the flag) and returns the stored error code (or the
+   pthread_once error).
+
+   (That's the basic idea.  With some debugging assert() calls and
+   such, it's a bit more complicated.  And we also need to handle
+   doing the pthread test at run time on systems where that works, so
+   we use the k5_once_t stuff instead.)
+
+   UNIX, with compiler support: MAKE_FINI_FUNCTION declares the
+   function as a destructor, and the run time linker support or
+   whatever will cause it to be invoked when the library is unloaded,
+   the program ends, etc.
+
+   UNIX, with linker support: MAKE_FINI_FUNCTION creates a symbol with
+   a magic name that is sought at library build time, and linker
+   options are used to mark it as a finalization function for the
+   library.  The symbol must be exported.
+
+   UNIX, no library finalization support: The finalization function
+   never runs, and we leak memory.  Tough.
+
+   DELAY_INITIALIZER will be defined by the configure script if we
+   want to use k5_once instead of load-time initialization.  That'll
+   be the preferred method on most systems except Windows, where we
+   have to initialize some mutexes.
+
+
+
+
+   For maximum flexibility in defining the macros, the function name
+   parameter should be a simple name, not even a macro defined as
+   another name.  The function should have a unique name, and should
+   conform to whatever namespace is used by the library in question.
+   (We do have export lists, but (1) they're not used for all
+   platforms, and (2) they're not used for static libraries.)
+
+   If the macro expansion needs the function to have been declared, it
+   must include a declaration.  If it is not necessary for the symbol
+   name to be exported from the object file, the macro should declare
+   it as "static".  Hence the signature must exactly match "void
+   foo(void)".  (ANSI C allows a static declaration followed by a
+   non-static one; the result is internal linkage.)  The macro
+   expansion has to come before the function, because gcc apparently
+   won't act on "__attribute__((constructor))" if it comes after the
+   function definition.
+
+   This is going to be compiler- and environment-specific, and may
+   require some support at library build time, and/or "asm"
+   statements.  But through macro expansion and auxiliary functions,
+   we should be able to handle most things except #pragma.
+
+   It's okay for this code to require that the library be built
+   with the same compiler and compiler options throughout, but
+   we shouldn't require that the library and application use the
+   same compiler.
+
+   For static libraries, we don't really care about cleanup too much,
+   since it's all memory handling and mutex allocation which will all
+   be cleaned up when the program exits.  Thus, it's okay if gcc-built
+   static libraries don't play nicely with cc-built executables when
+   it comes to static constructors, just as long as it doesn't cause
+   linking to fail.
+
+   For dynamic libraries on UNIX, we'll use pthread_once-type support
+   to do delayed initialization, so if finalization can't be made to
+   work, we'll only have memory leaks in a load/use/unload cycle.  If
+   anyone (like, say, the OS vendor) complains about this, they can
+   tell us how to get a shared library finalization function invoked
+   automatically.
+
+   Currently there's --disable-delayed-initialization for preventing
+   the initialization from being delayed on UNIX, but that's mainly
+   just for testing the linker options for initialization, and will
+   probably be removed at some point.  */
+
+/* Helper macros.  */
+
+# define JOIN__2_2(A,B) A ## _ ## _ ## B
+# define JOIN__2(A,B) JOIN__2_2(A,B)
+
+/* XXX Should test USE_LINKER_INIT_OPTION early, and if it's set,
+   always provide a function by the expected name, even if we're
+   delaying initialization.  */
+
+#if defined(DELAY_INITIALIZER)
+
+/* Run the initialization code during program execution, at the latest
+   possible moment.  This means multiple threads may be active.  */
+# include "k5-thread.h"
+typedef struct { k5_once_t once; int error, did_run; void (*fn)(void); } k5_init_t;
+# ifdef USE_LINKER_INIT_OPTION
+#  define MAYBE_DUMMY_INIT(NAME)                \
+        void JOIN__2(NAME, auxinit) () { }
+# else
+#  define MAYBE_DUMMY_INIT(NAME)
+# endif
+# ifdef __GNUC__
+/* Do it in macro form so we get the file/line of the invocation if
+   the assertion fails.  */
+#  define k5_call_init_function(I)                                      \
+        (__extension__ ({                                               \
+                k5_init_t *k5int_i = (I);                               \
+                int k5int_err = k5_once(&k5int_i->once, k5int_i->fn);   \
+                (k5int_err                                              \
+                 ? k5int_err                                            \
+                 : (assert(k5int_i->did_run != 0), k5int_i->error));    \
+            }))
+#  define MAYBE_DEFINE_CALLINIT_FUNCTION
+# else
+#  define MAYBE_DEFINE_CALLINIT_FUNCTION                        \
+        static inline int k5_call_init_function(k5_init_t *i)   \
+        {                                                       \
+            int err;                                            \
+            err = k5_once(&i->once, i->fn);                     \
+            if (err)                                            \
+                return err;                                     \
+            assert (i->did_run != 0);                           \
+            return i->error;                                    \
+        }
+# endif
+# define MAKE_INIT_FUNCTION(NAME)                               \
+        static int NAME(void);                                  \
+        MAYBE_DUMMY_INIT(NAME)                                  \
+        /* forward declaration for use in initializer */        \
+        static void JOIN__2(NAME, aux) (void);                  \
+        static k5_init_t JOIN__2(NAME, once) =                  \
+                { K5_ONCE_INIT, 0, 0, JOIN__2(NAME, aux) };     \
+        MAYBE_DEFINE_CALLINIT_FUNCTION                          \
+        static void JOIN__2(NAME, aux) (void)                   \
+        {                                                       \
+            JOIN__2(NAME, once).did_run = 1;                    \
+            JOIN__2(NAME, once).error = NAME();                 \
+        }                                                       \
+        /* so ';' following macro use won't get error */        \
+        static int NAME(void)
+# define CALL_INIT_FUNCTION(NAME)       \
+        k5_call_init_function(& JOIN__2(NAME, once))
+/* This should be called in finalization only, so we shouldn't have
+   multiple active threads mucking around in our library at this
+   point.  So ignore the once_t object and just look at the flag.
+
+   XXX Could we have problems with memory coherence between processors
+   if we don't invoke mutex/once routines?  Probably not, the
+   application code should already be coordinating things such that
+   the library code is not in use by this point, and memory
+   synchronization will be needed there.  */
+# define INITIALIZER_RAN(NAME)  \
+        (JOIN__2(NAME, once).did_run && JOIN__2(NAME, once).error == 0)
+
+# define PROGRAM_EXITING()              (0)
+
+#elif defined(__GNUC__) && !defined(_WIN32) && defined(CONSTRUCTOR_ATTR_WORKS)
+
+/* Run initializer at load time, via GCC/C++ hook magic.  */
+
+# ifdef USE_LINKER_INIT_OPTION
+     /* Both gcc and linker option??  Favor gcc.  */
+#  define MAYBE_DUMMY_INIT(NAME)                \
+        void JOIN__2(NAME, auxinit) () { }
+# else
+#  define MAYBE_DUMMY_INIT(NAME)
+# endif
+
+typedef struct { int error; unsigned char did_run; } k5_init_t;
+# define MAKE_INIT_FUNCTION(NAME)               \
+        MAYBE_DUMMY_INIT(NAME)                  \
+        static k5_init_t JOIN__2(NAME, ran)     \
+                = { 0, 2 };                     \
+        static void JOIN__2(NAME, aux)(void)    \
+            __attribute__((constructor));       \
+        static int NAME(void);                  \
+        static void JOIN__2(NAME, aux)(void)    \
+        {                                       \
+            JOIN__2(NAME, ran).error = NAME();  \
+            JOIN__2(NAME, ran).did_run = 3;     \
+        }                                       \
+        static int NAME(void)
+# define CALL_INIT_FUNCTION(NAME)               \
+        (JOIN__2(NAME, ran).did_run == 3        \
+         ? JOIN__2(NAME, ran).error             \
+         : (abort(),0))
+# define INITIALIZER_RAN(NAME)  (JOIN__2(NAME,ran).did_run == 3 && JOIN__2(NAME, ran).error == 0)
+
+# define PROGRAM_EXITING()              (0)
+
+#elif defined(USE_LINKER_INIT_OPTION) || defined(_WIN32)
+
+/* Run initializer at load time, via linker magic, or in the
+   case of WIN32, win_glue.c hard-coded knowledge.  */
+typedef struct { int error; unsigned char did_run; } k5_init_t;
+# define MAKE_INIT_FUNCTION(NAME)               \
+        static k5_init_t JOIN__2(NAME, ran)     \
+                = { 0, 2 };                     \
+        static int NAME(void);                  \
+        void JOIN__2(NAME, auxinit)()           \
+        {                                       \
+            JOIN__2(NAME, ran).error = NAME();  \
+            JOIN__2(NAME, ran).did_run = 3;     \
+        }                                       \
+        static int NAME(void)
+# define CALL_INIT_FUNCTION(NAME)               \
+        (JOIN__2(NAME, ran).did_run == 3        \
+         ? JOIN__2(NAME, ran).error             \
+         : (abort(),0))
+# define INITIALIZER_RAN(NAME)  \
+        (JOIN__2(NAME, ran).error == 0)
+
+# define PROGRAM_EXITING()              (0)
+
+#else
+
+# error "Don't know how to do load-time initializers for this configuration."
+
+# define PROGRAM_EXITING()              (0)
+
+#endif
+
+
+
+#if defined(USE_LINKER_FINI_OPTION) || defined(_WIN32)
+/* If we're told the linker option will be used, it doesn't really
+   matter what compiler we're using.  Do it the same way
+   regardless.  */
+
+# ifdef __hpux
+
+     /* On HP-UX, we need this auxiliary function.  At dynamic load or
+        unload time (but *not* program startup and termination for
+        link-time specified libraries), the linker-indicated function
+        is called with a handle on the library and a flag indicating
+        whether it's being loaded or unloaded.
+
+        The "real" fini function doesn't need to be exported, so
+        declare it static.
+
+        As usual, the final declaration is just for syntactic
+        convenience, so the top-level invocation of this macro can be
+        followed by a semicolon.  */
+
+#  include <dl.h>
+#  define MAKE_FINI_FUNCTION(NAME)                                          \
+        static void NAME(void);                                             \
+        void JOIN__2(NAME, auxfini)(shl_t, int); /* silence gcc warnings */ \
+        void JOIN__2(NAME, auxfini)(shl_t h, int l) { if (!l) NAME(); }     \
+        static void NAME(void)
+
+# else /* not hpux */
+
+#  define MAKE_FINI_FUNCTION(NAME)      \
+        void NAME(void)
+
+# endif
+
+#elif !defined(SHARED)
+
+/*
+ * In this case, we just don't care about finalization.  The code will still
+ * define the function, but we won't do anything with it.
+ */
+# define MAKE_FINI_FUNCTION(NAME)               \
+        static void NAME(void) UNUSED
+
+#elif defined(__GNUC__) && defined(DESTRUCTOR_ATTR_WORKS)
+/* If we're using gcc, if the C++ support works, the compiler should
+   build executables and shared libraries that support the use of
+   static constructors and destructors.  The C compiler supports a
+   function attribute that makes use of the same facility as C++.
+
+   XXX How do we know if the C++ support actually works?  */
+# define MAKE_FINI_FUNCTION(NAME)       \
+        static void NAME(void) __attribute__((destructor))
+
+#else
+
+# error "Don't know how to do unload-time finalization for this configuration."
+
+#endif
+
+#ifndef SIZE_MAX
+# define SIZE_MAX ((size_t)((size_t)0 - 1))
+#endif
+
+#ifdef _WIN32
+# define SSIZE_MAX ((ssize_t)(SIZE_MAX/2))
+#endif
+
+/* Read and write integer values as (unaligned) octet strings in
+   specific byte orders.  Add per-platform optimizations as
+   needed.  */
+
+#if HAVE_ENDIAN_H
+# include <endian.h>
+#elif HAVE_MACHINE_ENDIAN_H
+# include <machine/endian.h>
+#endif
+/* Check for BIG/LITTLE_ENDIAN macros.  If exactly one is defined, use
+   it.  If both are defined, then BYTE_ORDER should be defined and
+   match one of them.  Try those symbols, then try again with an
+   underscore prefix.  */
+#if defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
+# if BYTE_ORDER == BIG_ENDIAN
+#  define K5_BE
+# endif
+# if BYTE_ORDER == LITTLE_ENDIAN
+#  define K5_LE
+# endif
+#elif defined(BIG_ENDIAN)
+# define K5_BE
+#elif defined(LITTLE_ENDIAN)
+# define K5_LE
+#elif defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
+# if _BYTE_ORDER == _BIG_ENDIAN
+#  define K5_BE
+# endif
+# if _BYTE_ORDER == _LITTLE_ENDIAN
+#  define K5_LE
+# endif
+#elif defined(_BIG_ENDIAN)
+# define K5_BE
+#elif defined(_LITTLE_ENDIAN)
+# define K5_LE
+#elif defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
+# define K5_BE
+#elif defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+# define K5_LE
+#endif
+#if !defined(K5_BE) && !defined(K5_LE)
+/* Look for some architectures we know about.
+
+   MIPS can use either byte order, but the preprocessor tells us which
+   mode we're compiling for.  The GCC config files indicate that
+   variants of Alpha and IA64 might be out there with both byte
+   orders, but until we encounter the "wrong" ones in the real world,
+   just go with the default (unless there are cpp predefines to help
+   us there too).
+
+   As far as I know, only PDP11 and ARM (which we don't handle here)
+   have strange byte orders where an 8-byte value isn't laid out as
+   either 12345678 or 87654321.  */
+# if defined(__i386__) || defined(_MIPSEL) || defined(__alpha__) || (defined(__ia64__) && !defined(__hpux))
+#  define K5_LE
+# endif
+# if defined(__hppa__) || defined(__rs6000__) || defined(__sparc__) || defined(_MIPSEB) || defined(__m68k__) || defined(__sparc64__) || defined(__ppc__) || defined(__ppc64__) || (defined(__hpux) && defined(__ia64__))
+#  define K5_BE
+# endif
+#endif
+#if defined(K5_BE) && defined(K5_LE)
+# error "oops, check the byte order macros"
+#endif
+
+/* Optimize for GCC on platforms with known byte orders.
+
+   GCC's packed structures can be written to with any alignment; the
+   compiler will use byte operations, unaligned-word operations, or
+   normal memory ops as appropriate for the architecture.
+
+   This assumes the availability of uint##_t types, which should work
+   on most of our platforms except Windows, where we're not using
+   GCC.  */
+#ifdef __GNUC__
+# define PUT(SIZE,PTR,VAL)      (((struct { uint##SIZE##_t i; } __attribute__((packed)) *)(PTR))->i = (VAL))
+# define GET(SIZE,PTR)          (((const struct { uint##SIZE##_t i; } __attribute__((packed)) *)(PTR))->i)
+# define PUTSWAPPED(SIZE,PTR,VAL)       PUT(SIZE,PTR,SWAP##SIZE(VAL))
+# define GETSWAPPED(SIZE,PTR)           SWAP##SIZE(GET(SIZE,PTR))
+#endif
+/* To do: Define SWAP16, SWAP32, SWAP64 macros to byte-swap values
+   with the indicated numbers of bits.
+
+   Linux: byteswap.h, bswap_16 etc.
+   Solaris 10: none
+   macOS: machine/endian.h or byte_order.h, NXSwap{Short,Int,LongLong}
+   NetBSD: sys/bswap.h, bswap16 etc.  */
+
+#if defined(HAVE_BYTESWAP_H) && defined(HAVE_BSWAP_16)
+# include <byteswap.h>
+# define SWAP16                 bswap_16
+# define SWAP32                 bswap_32
+# ifdef HAVE_BSWAP_64
+#  define SWAP64                bswap_64
+# endif
+#elif TARGET_OS_MAC
+# include <architecture/byte_order.h>
+# define SWAP16                k5_swap16
+static inline unsigned int k5_swap16 (unsigned int x) {
+    x &= 0xffff;
+    return (x >> 8) | ((x & 0xff) << 8);
+}
+# define SWAP32                 OSSwapInt32
+# define SWAP64                 OSSwapInt64
+#elif defined(HAVE_SYS_BSWAP_H)
+/* XXX NetBSD/x86 5.0.1 defines bswap16 and bswap32 as inline
+   functions only, so autoconf doesn't pick up on their existence.
+   So, no feature macro test for them here.  The 64-bit version isn't
+   inline at all, though, for whatever reason.  */
+# include <sys/bswap.h>
+# define SWAP16                 bswap16
+# define SWAP32                 bswap32
+/* However, bswap64 causes lots of warnings about 'long long'
+   constants; probably only on 32-bit platforms.  */
+# if LONG_MAX > 0x7fffffffL
+#  define SWAP64                bswap64
+# endif
+#endif
+
+/* Note that on Windows at least this file can be included from C++
+   source, so casts *from* void* are required.  */
+static inline void
+store_16_be (unsigned int val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    PUT(16,p,val);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP16) && !defined(__cplusplus)
+    PUTSWAPPED(16,p,val);
+#else
+    p[0] = (val >>  8) & 0xff;
+    p[1] = (val      ) & 0xff;
+#endif
+}
+static inline void
+store_32_be (unsigned int val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    PUT(32,p,val);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP32) && !defined(__cplusplus)
+    PUTSWAPPED(32,p,val);
+#else
+    p[0] = (val >> 24) & 0xff;
+    p[1] = (val >> 16) & 0xff;
+    p[2] = (val >>  8) & 0xff;
+    p[3] = (val      ) & 0xff;
+#endif
+}
+static inline void
+store_64_be (uint64_t val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    PUT(64,p,val);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP64) && !defined(__cplusplus)
+    PUTSWAPPED(64,p,val);
+#else
+    p[0] = (unsigned char)((val >> 56) & 0xff);
+    p[1] = (unsigned char)((val >> 48) & 0xff);
+    p[2] = (unsigned char)((val >> 40) & 0xff);
+    p[3] = (unsigned char)((val >> 32) & 0xff);
+    p[4] = (unsigned char)((val >> 24) & 0xff);
+    p[5] = (unsigned char)((val >> 16) & 0xff);
+    p[6] = (unsigned char)((val >>  8) & 0xff);
+    p[7] = (unsigned char)((val      ) & 0xff);
+#endif
+}
+static inline unsigned short
+load_16_be (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    return GET(16,p);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP16) && !defined(__cplusplus)
+    return GETSWAPPED(16,p);
+#else
+    return (p[1] | (p[0] << 8));
+#endif
+}
+static inline unsigned int
+load_32_be (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    return GET(32,p);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP32) && !defined(__cplusplus)
+    return GETSWAPPED(32,p);
+#else
+    return (p[3] | (p[2] << 8)
+            | ((uint32_t) p[1] << 16)
+            | ((uint32_t) p[0] << 24));
+#endif
+}
+static inline uint64_t
+load_64_be (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_BE) && !defined(__cplusplus)
+    return GET(64,p);
+#elif defined(__GNUC__) && defined(K5_LE) && defined(SWAP64) && !defined(__cplusplus)
+    return GETSWAPPED(64,p);
+#else
+    return ((uint64_t)load_32_be(p) << 32) | load_32_be(p+4);
+#endif
+}
+static inline void
+store_16_le (unsigned int val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    PUT(16,p,val);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP16) && !defined(__cplusplus)
+    PUTSWAPPED(16,p,val);
+#else
+    p[1] = (val >>  8) & 0xff;
+    p[0] = (val      ) & 0xff;
+#endif
+}
+static inline void
+store_32_le (unsigned int val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    PUT(32,p,val);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP32) && !defined(__cplusplus)
+    PUTSWAPPED(32,p,val);
+#else
+    p[3] = (val >> 24) & 0xff;
+    p[2] = (val >> 16) & 0xff;
+    p[1] = (val >>  8) & 0xff;
+    p[0] = (val      ) & 0xff;
+#endif
+}
+static inline void
+store_64_le (uint64_t val, void *vp)
+{
+    unsigned char *p = (unsigned char *) vp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    PUT(64,p,val);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP64) && !defined(__cplusplus)
+    PUTSWAPPED(64,p,val);
+#else
+    p[7] = (unsigned char)((val >> 56) & 0xff);
+    p[6] = (unsigned char)((val >> 48) & 0xff);
+    p[5] = (unsigned char)((val >> 40) & 0xff);
+    p[4] = (unsigned char)((val >> 32) & 0xff);
+    p[3] = (unsigned char)((val >> 24) & 0xff);
+    p[2] = (unsigned char)((val >> 16) & 0xff);
+    p[1] = (unsigned char)((val >>  8) & 0xff);
+    p[0] = (unsigned char)((val      ) & 0xff);
+#endif
+}
+static inline unsigned short
+load_16_le (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    return GET(16,p);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP16) && !defined(__cplusplus)
+    return GETSWAPPED(16,p);
+#else
+    return (p[0] | (p[1] << 8));
+#endif
+}
+static inline unsigned int
+load_32_le (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    return GET(32,p);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP32) && !defined(__cplusplus)
+    return GETSWAPPED(32,p);
+#else
+    return (p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24));
+#endif
+}
+static inline uint64_t
+load_64_le (const void *cvp)
+{
+    const unsigned char *p = (const unsigned char *) cvp;
+#if defined(__GNUC__) && defined(K5_LE) && !defined(__cplusplus)
+    return GET(64,p);
+#elif defined(__GNUC__) && defined(K5_BE) && defined(SWAP64) && !defined(__cplusplus)
+    return GETSWAPPED(64,p);
+#else
+    return ((uint64_t)load_32_le(p+4) << 32) | load_32_le(p);
+#endif
+}
+
+#define UINT16_TYPE uint16_t
+#define UINT32_TYPE uint32_t
+
+static inline void
+store_16_n (unsigned int val, void *vp)
+{
+    UINT16_TYPE n = val;
+    memcpy(vp, &n, 2);
+}
+static inline void
+store_32_n (unsigned int val, void *vp)
+{
+    UINT32_TYPE n = val;
+    memcpy(vp, &n, 4);
+}
+static inline void
+store_64_n (uint64_t val, void *vp)
+{
+    uint64_t n = val;
+    memcpy(vp, &n, 8);
+}
+static inline unsigned short
+load_16_n (const void *p)
+{
+    UINT16_TYPE n;
+    memcpy(&n, p, 2);
+    return n;
+}
+static inline unsigned int
+load_32_n (const void *p)
+{
+    UINT32_TYPE n;
+    memcpy(&n, p, 4);
+    return n;
+}
+static inline uint64_t
+load_64_n (const void *p)
+{
+    uint64_t n;
+    memcpy(&n, p, 8);
+    return n;
+}
+#undef UINT16_TYPE
+#undef UINT32_TYPE
+
+/* Assume for simplicity that these swaps are identical.  */
+static inline uint64_t
+k5_htonll (uint64_t val)
+{
+#ifdef K5_BE
+    return val;
+#elif defined K5_LE && defined SWAP64
+    return SWAP64 (val);
+#else
+    return load_64_be ((unsigned char *)&val);
+#endif
+}
+static inline uint64_t
+k5_ntohll (uint64_t val)
+{
+    return k5_htonll (val);
+}
+
+/* Make the interfaces to getpwnam and getpwuid consistent.
+   Model the wrappers on the POSIX thread-safe versions, but
+   use the unsafe system versions if the safe ones don't exist
+   or we can't figure out their interfaces.  */
+
+/* int k5_getpwnam_r(const char *, blah blah) */
+#ifdef HAVE_GETPWNAM_R
+# ifndef GETPWNAM_R_4_ARGS
+/* POSIX */
+#  define k5_getpwnam_r(NAME, REC, BUF, BUFSIZE, OUT)   \
+        (getpwnam_r(NAME,REC,BUF,BUFSIZE,OUT) == 0      \
+         ? (*(OUT) == NULL ? -1 : 0) : -1)
+# else
+/* POSIX drafts? */
+#  ifdef GETPWNAM_R_RETURNS_INT
+#   define k5_getpwnam_r(NAME, REC, BUF, BUFSIZE, OUT)  \
+        (getpwnam_r(NAME,REC,BUF,BUFSIZE) == 0          \
+         ? (*(OUT) = REC, 0)                            \
+         : (*(OUT) = NULL, -1))
+#  else
+#   define k5_getpwnam_r(NAME, REC, BUF, BUFSIZE, OUT)  \
+        (*(OUT) = getpwnam_r(NAME,REC,BUF,BUFSIZE), *(OUT) == NULL ? -1 : 0)
+#  endif
+# endif
+#else /* no getpwnam_r, or can't figure out #args or return type */
+/* Will get warnings about unused variables.  */
+# define k5_getpwnam_r(NAME, REC, BUF, BUFSIZE, OUT) \
+        (*(OUT) = getpwnam(NAME), *(OUT) == NULL ? -1 : 0)
+#endif
+
+/* int k5_getpwuid_r(uid_t, blah blah) */
+#ifdef HAVE_GETPWUID_R
+# ifndef GETPWUID_R_4_ARGS
+/* POSIX */
+#  define k5_getpwuid_r(UID, REC, BUF, BUFSIZE, OUT)    \
+        (getpwuid_r(UID,REC,BUF,BUFSIZE,OUT) == 0       \
+         ? (*(OUT) == NULL ? -1 : 0) : -1)
+# else
+/* POSIX drafts?  Yes, I mean to test GETPWNAM... here.  Less junk to
+   do at configure time.  */
+#  ifdef GETPWNAM_R_RETURNS_INT
+#   define k5_getpwuid_r(UID, REC, BUF, BUFSIZE, OUT)   \
+        (getpwuid_r(UID,REC,BUF,BUFSIZE) == 0           \
+         ? (*(OUT) = REC, 0)                            \
+         : (*(OUT) = NULL, -1))
+#  else
+#   define k5_getpwuid_r(UID, REC, BUF, BUFSIZE, OUT)  \
+        (*(OUT) = getpwuid_r(UID,REC,BUF,BUFSIZE), *(OUT) == NULL ? -1 : 0)
+#  endif
+# endif
+#else /* no getpwuid_r, or can't figure out #args or return type */
+/* Will get warnings about unused variables.  */
+# define k5_getpwuid_r(UID, REC, BUF, BUFSIZE, OUT) \
+        (*(OUT) = getpwuid(UID), *(OUT) == NULL ? -1 : 0)
+#endif
+
+/* Ensure, if possible, that the indicated file descriptor won't be
+   kept open if we exec another process (e.g., launching a ccapi
+   server).  If we don't know how to do it... well, just go about our
+   business.  Probably most callers won't check the return status
+   anyways.  */
+
+/* Macros make the Sun compiler happier, and all variants of this do a
+   single evaluation of the argument, and fcntl and fileno should
+   produce reasonable error messages on type mismatches, on any system
+   with F_SETFD.  */
+#ifdef F_SETFD
+# ifdef FD_CLOEXEC
+#  define set_cloexec_fd(FD)    ((void)fcntl((FD), F_SETFD, FD_CLOEXEC))
+# else
+#  define set_cloexec_fd(FD)    ((void)fcntl((FD), F_SETFD, 1))
+# endif
+#else
+# define set_cloexec_fd(FD)     ((void)(FD))
+#endif
+#define set_cloexec_file(F)     set_cloexec_fd(fileno(F))
+
+/* Since the original ANSI C spec left it undefined whether or
+   how you could copy around a va_list, C 99 added va_copy.
+   For old implementations, let's do our best to fake it.
+
+   XXX Doesn't yet handle implementations with __va_copy (early draft)
+   or GCC's __builtin_va_copy.  */
+#if defined(HAS_VA_COPY) || defined(va_copy)
+/* Do nothing.  */
+#elif defined(CAN_COPY_VA_LIST)
+#define va_copy(dest, src)      ((dest) = (src))
+#else
+/* Assume array type, but still simply copyable.
+
+   There is, theoretically, the possibility that va_start will
+   allocate some storage pointed to by the va_list, and in that case
+   we'll just lose.  If anyone cares, we could try to devise a test
+   for that case.  */
+#define va_copy(dest, src)      memcpy(dest, src, sizeof(va_list))
+#endif
+
+/* Provide strlcpy/strlcat interfaces. */
+#ifndef HAVE_STRLCPY
+#define strlcpy krb5int_strlcpy
+#define strlcat krb5int_strlcat
+extern size_t krb5int_strlcpy(char *dst, const char *src, size_t siz);
+extern size_t krb5int_strlcat(char *dst, const char *src, size_t siz);
+#endif
+
+/* Provide fnmatch interface. */
+#ifndef HAVE_FNMATCH
+#define fnmatch k5_fnmatch
+int k5_fnmatch(const char *pattern, const char *string, int flags);
+#define FNM_NOMATCH     1       /* Match failed. */
+#define FNM_NOSYS       2       /* Function not implemented. */
+#define FNM_NORES       3       /* Out of resources */
+#define FNM_NOESCAPE    0x01    /* Disable backslash escaping. */
+#define FNM_PATHNAME    0x02    /* Slash must be matched by slash. */
+#define FNM_PERIOD      0x04    /* Period must be matched by period. */
+#define FNM_CASEFOLD    0x08    /* Pattern is matched case-insensitive */
+#define FNM_LEADING_DIR 0x10    /* Ignore /<tail> after Imatch. */
+#endif
+
+/* Provide [v]asprintf interfaces.  */
+#ifndef HAVE_VSNPRINTF
+#ifdef _WIN32
+static inline int
+vsnprintf(char *str, size_t size, const char *format, va_list args)
+{
+    va_list args_copy;
+    int length;
+
+    va_copy(args_copy, args);
+    length = _vscprintf(format, args_copy);
+    va_end(args_copy);
+    if (size > 0) {
+        _vsnprintf(str, size, format, args);
+        str[size - 1] = '\0';
+    }
+    return length;
+}
+static inline int
+snprintf(char *str, size_t size, const char *format, ...)
+{
+    va_list args;
+    int n;
+
+    va_start(args, format);
+    n = vsnprintf(str, size, format, args);
+    va_end(args);
+    return n;
+}
+#else /* not win32 */
+#error We need an implementation of vsnprintf.
+#endif /* win32? */
+#endif /* no vsnprintf */
+
+#ifndef HAVE_VASPRINTF
+
+extern int krb5int_vasprintf(char **, const char *, va_list)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 0)))
+#endif
+    ;
+extern int krb5int_asprintf(char **, const char *, ...)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 3)))
+#endif
+    ;
+
+#define vasprintf krb5int_vasprintf
+/* Assume HAVE_ASPRINTF iff HAVE_VASPRINTF.  */
+#define asprintf krb5int_asprintf
+
+#elif defined(NEED_VASPRINTF_PROTO)
+
+extern int vasprintf(char **, const char *, va_list)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 0)))
+#endif
+    ;
+extern int asprintf(char **, const char *, ...)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 3)))
+#endif
+    ;
+
+#endif /* have vasprintf and prototype? */
+
+/* Return true if the snprintf return value RESULT reflects a buffer
+   overflow for the buffer size SIZE.
+
+   We cast the result to unsigned int for two reasons.  First, old
+   implementations of snprintf (such as the one in Solaris 9 and
+   prior) return -1 on a buffer overflow.  Casting the result to -1
+   will convert that value to UINT_MAX, which should compare larger
+   than any reasonable buffer size.  Second, comparing signed and
+   unsigned integers will generate warnings with some compilers, and
+   can have unpredictable results, particularly when the relative
+   widths of the types is not known (size_t may be the same width as
+   int or larger).
+*/
+#define SNPRINTF_OVERFLOW(result, size) \
+    ((unsigned int)(result) >= (size_t)(size))
+
+#if defined(_WIN32) || !defined(HAVE_STRERROR_R) || defined(STRERROR_R_CHAR_P)
+#define strerror_r k5_strerror_r
+#endif
+extern int k5_strerror_r(int errnum, char *buf, size_t buflen);
+
+#ifndef HAVE_MKSTEMP
+extern int krb5int_mkstemp(char *);
+#define mkstemp krb5int_mkstemp
+#endif
+
+#ifndef HAVE_GETTIMEOFDAY
+extern int krb5int_gettimeofday(struct timeval *tp, void *ignore);
+#define gettimeofday krb5int_gettimeofday
+#endif
+
+/*
+ * Attempt to zero memory in a way that compilers won't optimize out.
+ *
+ * This mechanism should work even for heap storage about to be freed,
+ * or automatic storage right before we return from a function.
+ *
+ * Then, even if we leak uninitialized memory someplace, or UNIX
+ * "core" files get created with world-read access, some of the most
+ * sensitive data in the process memory will already be safely wiped.
+ *
+ * We're not going so far -- yet -- as to try to protect key data that
+ * may have been written into swap space....
+ */
+#ifdef _WIN32
+# define zap(ptr, len) SecureZeroMemory(ptr, len)
+#elif defined(__STDC_LIB_EXT1__)
+/*
+ * Use memset_s() which cannot be optimized out.  Avoid memset_s(NULL, 0, 0, 0)
+ * which would cause a runtime constraint violation.
+ */
+static inline void zap(void *ptr, size_t len)
+{
+    if (len > 0)
+        memset_s(ptr, len, 0, len);
+}
+#elif defined(HAVE_EXPLICIT_BZERO)
+# define zap(ptr, len) explicit_bzero(ptr, len)
+#elif defined(HAVE_EXPLICIT_MEMSET)
+# define zap(ptr, len) explicit_memset(ptr, 0, len)
+#elif defined(__GNUC__) || defined(__clang__)
+/*
+ * Use an asm statement which declares a memory clobber to force the memset to
+ * be carried out.  Avoid memset(NULL, 0, 0) which has undefined behavior.
+ */
+static inline void zap(void *ptr, size_t len)
+{
+    if (len > 0)
+        memset(ptr, 0, len);
+    __asm__ __volatile__("" : : "g" (ptr) : "memory");
+}
+#else
+/*
+ * Use a function from libkrb5support to defeat inlining unless link-time
+ * optimization is used.  The function uses a volatile pointer, which prevents
+ * current compilers from optimizing out the memset.
+ */
+# define zap(ptr, len) krb5int_zap(ptr, len)
+#endif
+
+extern void krb5int_zap(void *ptr, size_t len);
+
+/*
+ * Return 0 if the n-byte memory regions p1 and p2 are equal, and nonzero if
+ * they are not.  The function is intended to take the same amount of time
+ * regardless of how many bytes of p1 and p2 are equal.
+ */
+int k5_bcmp(const void *p1, const void *p2, size_t n);
+
+/*
+ * Split a path into parent directory and basename.  Either output parameter
+ * may be NULL if the caller doesn't need it.  parent_out will be empty if path
+ * has no basename.  basename_out will be empty if path ends with a path
+ * separator.  Returns 0 on success or ENOMEM on allocation failure.
+ */
+long k5_path_split(const char *path, char **parent_out, char **basename_out);
+
+/*
+ * Compose two path components, inserting the platform-appropriate path
+ * separator if needed.  If path2 is an absolute path, path1 will be discarded
+ * and path_out will be a copy of path2.  Returns 0 on success or ENOMEM on
+ * allocation failure.
+ */
+long k5_path_join(const char *path1, const char *path2, char **path_out);
+
+/* Return 1 if path is absolute, 0 if it is relative. */
+int k5_path_isabs(const char *path);
+
+/*
+ * Localization macros.  If we have gettext, define _ appropriately for
+ * translating a string.  If we do not have gettext, define _ and
+ * bindtextdomain as no-ops.  N_ is always a no-op; it marks a string for
+ * extraction to pot files but does not translate it.
+ */
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define KRB5_TEXTDOMAIN "mit-krb5"
+#define _(s) dgettext(KRB5_TEXTDOMAIN, s)
+#else
+#define _(s) s
+#define dgettext(d, m) m
+#define ngettext(m1, m2, n) (((n) == 1) ? m1 : m2)
+#define bindtextdomain(p, d)
+#endif
+#define N_(s) s
+
+#if !defined(HAVE_GETOPT) || !defined(HAVE_UNISTD_H)
+/* Data objects imported from DLLs must be declared as such on Windows. */
+#if defined(_WIN32) && !defined(K5_GETOPT_C)
+#define K5_GETOPT_DECL __declspec(dllimport)
+#else
+#define K5_GETOPT_DECL
+#endif
+K5_GETOPT_DECL extern int k5_opterr;
+K5_GETOPT_DECL extern int k5_optind;
+K5_GETOPT_DECL extern int k5_optopt;
+K5_GETOPT_DECL extern char *k5_optarg;
+#define opterr k5_opterr
+#define optind k5_optind
+#define optopt k5_optopt
+#define optarg k5_optarg
+
+extern int k5_getopt(int nargc, char * const nargv[], const char *ostr);
+#define getopt k5_getopt
+#endif /* HAVE_GETOPT */
+
+#ifdef HAVE_GETOPT_LONG
+#include <getopt.h>
+#else
+
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+
+#define no_argument       0
+#define required_argument 1
+#define optional_argument 2
+
+extern int k5_getopt_long(int nargc, char **nargv, char *options,
+                          struct option *long_options, int *index);
+#define getopt_long k5_getopt_long
+#endif /* HAVE_GETOPT_LONG */
+
+#if defined(_WIN32)
+/* On Windows there is never a need to ignore the process environment. */
+#define secure_getenv getenv
+#elif !defined(HAVE_SECURE_GETENV)
+#define secure_getenv k5_secure_getenv
+extern char *k5_secure_getenv(const char *name);
+#endif
+
+/* Set *fnames_out to a null-terminated list of filenames within dirname,
+ * sorted according to strcmp().  Return 0 on success, or ENOENT/ENOMEM. */
+int k5_dir_filenames(const char *dirname, char ***fnames_out);
+void k5_free_filenames(char **fnames);
+
+#endif /* K5_PLATFORM_H */

--- a/auth/kinit_client/k5-plugin.h
+++ b/auth/kinit_client/k5-plugin.h
@@ -1,0 +1,121 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright (C) 2006 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * This software is being provided to you, the LICENSEE, by the
+ * Massachusetts Institute of Technology (M.I.T.) under the following
+ * license.  By obtaining, using and/or copying this software, you agree
+ * that you have read, understood, and will comply with these terms and
+ * conditions:
+ *
+ * Export of this software from the United States of America may
+ * require a specific license from the United States Government.
+ * It is the responsibility of any person or organization contemplating
+ * export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify and distribute
+ * this software and its documentation for any purpose and without fee or
+ * royalty is hereby granted, provided that you agree to comply with the
+ * following copyright notice and statements, including the disclaimer, and
+ * that the same appear on ALL copies of the software and documentation,
+ * including modifications that you make for internal use or for
+ * distribution:
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS", AND M.I.T. MAKES NO REPRESENTATIONS
+ * OR WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+ * limitation, M.I.T. MAKES NO REPRESENTATIONS OR WARRANTIES OF
+ * MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+ * THE LICENSED SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY
+ * PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+ *
+ * The name of the Massachusetts Institute of Technology or M.I.T. may NOT
+ * be used in advertising or publicity pertaining to distribution of the
+ * software.  Title to copyright in this software and any associated
+ * documentation shall at all times remain with M.I.T., and USER agrees to
+ * preserve same.
+ *
+ * Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ */
+
+/* Just those definitions which are needed by util/support/plugins.c,
+   which gets compiled before util/et is built, which happens before
+   we can construct krb5.h, which is included by k5-int.h.
+
+   So, no krb5 types.  */
+
+#ifndef K5_PLUGIN_H
+#define K5_PLUGIN_H
+
+#if defined(_MSDOS) || defined(_WIN32)
+#include "win-mac.h"
+#endif
+#include "autoconf.h"
+#ifndef KRB5_CALLCONV
+#define KRB5_CALLCONV
+#define KRB5_CALLCONV_C
+#endif
+
+#include "k5-err.h"
+
+/*
+ * Plugins normally export fixed symbol names, but when statically
+ * linking plugins, we need a different symbol name for each plugin.
+ * The first argument to PLUGIN_SYMBOL_NAME acts as the
+ * differentiator, and is only used for static plugin linking.
+ *
+ * Although this macro (and thus this header file) are used in plugins
+ * whose code lies inside the krb5 tree, plugins maintained separately
+ * from the krb5 tree do not need it; they can just use the fixed
+ * symbol name unconditionally.
+ */
+#ifdef STATIC_PLUGINS
+#define PLUGIN_SYMBOL_NAME(prefix, symbol) prefix ## _ ## symbol
+#else
+#define PLUGIN_SYMBOL_NAME(prefix, symbol) symbol
+#endif
+
+struct plugin_file_handle;      /* opaque */
+
+struct plugin_dir_handle {
+    /* This points to a NULL-terminated list of pointers to plugin_file_handle structs */
+    struct plugin_file_handle **files;
+};
+#define PLUGIN_DIR_INIT(P) ((P)->files = NULL)
+#define PLUGIN_DIR_OPEN(P) ((P)->files != NULL)
+
+long KRB5_CALLCONV
+krb5int_open_plugin (const char *, struct plugin_file_handle **, struct errinfo *);
+void KRB5_CALLCONV
+krb5int_close_plugin (struct plugin_file_handle *);
+
+long KRB5_CALLCONV
+krb5int_get_plugin_data (struct plugin_file_handle *, const char *, void **,
+                         struct errinfo *);
+
+long KRB5_CALLCONV
+krb5int_get_plugin_func (struct plugin_file_handle *, const char *,
+                         void (**)(), struct errinfo *);
+
+
+long KRB5_CALLCONV
+krb5int_open_plugin_dirs (const char * const *, const char * const *,
+                          struct plugin_dir_handle *, struct errinfo *);
+void KRB5_CALLCONV
+krb5int_close_plugin_dirs (struct plugin_dir_handle *);
+
+long KRB5_CALLCONV
+krb5int_get_plugin_dir_data (struct plugin_dir_handle *, const char *,
+                             void ***, struct errinfo *);
+void KRB5_CALLCONV
+krb5int_free_plugin_dir_data (void **);
+
+long KRB5_CALLCONV
+krb5int_get_plugin_dir_func (struct plugin_dir_handle *, const char *,
+                             void (***)(void), struct errinfo *);
+void KRB5_CALLCONV
+krb5int_free_plugin_dir_func (void (**)(void));
+
+#endif /* K5_PLUGIN_H */

--- a/auth/kinit_client/k5-thread.h
+++ b/auth/kinit_client/k5-thread.h
@@ -1,0 +1,443 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-thread.h - Preliminary portable thread support */
+/*
+ * Copyright 2004,2005,2006,2007,2008 by the Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+#ifndef K5_THREAD_H
+#define K5_THREAD_H
+
+#include "autoconf.h"
+#ifndef KRB5_CALLCONV
+# define KRB5_CALLCONV
+#endif
+#ifndef KRB5_CALLCONV_C
+# define KRB5_CALLCONV_C
+#endif
+
+/* Interface (tentative):
+
+     Mutex support:
+
+     // Between these two, we should be able to do pure compile-time
+     // and pure run-time initialization.
+     //   POSIX:   partial initializer is PTHREAD_MUTEX_INITIALIZER,
+     //            finish does nothing
+     //   Windows: partial initializer is an invalid handle,
+     //            finish does the real initialization work
+     k5_mutex_t foo_mutex = K5_MUTEX_PARTIAL_INITIALIZER;
+     int k5_mutex_finish_init(k5_mutex_t *);
+     // for dynamic allocation
+     int k5_mutex_init(k5_mutex_t *);
+     // Must work for both kinds of alloc, even if it means adding flags.
+     int k5_mutex_destroy(k5_mutex_t *);
+
+     // As before.
+     int k5_mutex_lock(k5_mutex_t *);
+     int k5_mutex_unlock(k5_mutex_t *);
+
+     In each library, one new function to finish the static mutex init,
+     and any other library-wide initialization that might be desired.
+     On POSIX, this function would be called via the second support
+     function (see below).  On Windows, it would be called at library
+     load time.  These functions, or functions they calls, should be the
+     only places that k5_mutex_finish_init gets called.
+
+     A second function or macro called at various possible "first" entry
+     points which either calls pthread_once on the first function
+     (POSIX), or checks some flag set by the first function (Windows),
+     and possibly returns an error.  (In the non-threaded case, a simple
+     flag can be used to avoid multiple invocations, and the mutexes
+     don't need run-time initialization anyways.)
+
+     A third function for library termination calls mutex_destroy on
+     each mutex for the library.  This function would be called
+     automatically at library unload time.  If it turns out to be needed
+     at exit time for libraries that don't get unloaded, perhaps we
+     should also use atexit().  Any static mutexes should be cleaned up
+     with k5_mutex_destroy here.
+
+     How does that second support function invoke the first support
+     function only once?  Through something modelled on pthread_once
+     that I haven't written up yet.  Probably:
+
+     k5_once_t foo_once = K5_ONCE_INIT;
+     k5_once(k5_once_t *, void (*)(void));
+
+     For POSIX: Map onto pthread_once facility.
+     For non-threaded case: A simple flag.
+     For Windows: Not needed; library init code takes care of it.
+
+     XXX: A general k5_once mechanism isn't possible for Windows,
+     without faking it through named mutexes or mutexes initialized at
+     startup.  I was only using it in one place outside these headers,
+     so I'm dropping the general scheme.  Eventually the existing uses
+     in k5-thread.h and k5-platform.h will be converted to pthread_once
+     or static variables.
+
+
+     Thread-specific data:
+
+     // TSD keys are limited in number in gssapi/krb5/com_err; enumerate
+     // them all.  This allows support code init to allocate the
+     // necessary storage for pointers all at once, and avoids any
+     // possible error in key creation.
+     enum { ... } k5_key_t;
+     // Register destructor function.  Called in library init code.
+     int k5_key_register(k5_key_t, void (*destructor)(void *));
+     // Returns NULL or data.
+     void *k5_getspecific(k5_key_t);
+     // Returns error if key out of bounds, or the pointer table can't
+     // be allocated.  A call to k5_key_register must have happened first.
+     // This may trigger the calling of pthread_setspecific on POSIX.
+     int k5_setspecific(k5_key_t, void *);
+     // Called in library termination code.
+     // Trashes data in all threads, calling the registered destructor
+     // (but calling it from the current thread).
+     int k5_key_delete(k5_key_t);
+
+     For the non-threaded version, the support code will have a static
+     array indexed by k5_key_t values, and get/setspecific simply access
+     the array elements.
+
+     The TSD destructor table is global state, protected by a mutex if
+     threads are enabled.
+
+
+     Any actual external symbols will use the krb5int_ prefix.  The k5_
+     names will be simple macros or inline functions to rename the
+     external symbols, or slightly more complex ones to expand the
+     implementation inline (e.g., map to POSIX versions and/or debug
+     code using __FILE__ and the like).
+
+
+     More to be added, perhaps.  */
+
+#include <assert.h>
+#ifndef NDEBUG
+#include <stdio.h>
+#include <string.h>
+#endif
+
+/* The mutex structure we use, k5_mutex_t, is defined to some
+   OS-specific bits.  The use of multiple layers of typedefs are an
+   artifact resulting from debugging code we once used, implemented as
+   wrappers around the OS mutex scheme.
+
+   The OS specific bits, in k5_os_mutex, break down into three primary
+   implementations, POSIX threads, Windows threads, and no thread
+   support.  However, the POSIX thread version is further subdivided:
+   In one case, we can determine at run time whether the thread
+   library is linked into the application, and use it only if it is
+   present; in the other case, we cannot, and the thread library must
+   be linked in always, but can be used unconditionally.  In the
+   former case, the k5_os_mutex structure needs to hold both the POSIX
+   and the non-threaded versions.
+
+   The various k5_os_mutex_* operations are the OS-specific versions,
+   applied to the OS-specific data, and k5_mutex_* uses k5_os_mutex_*
+   to do the OS-specific parts of the work.  */
+
+/* Define the OS mutex bit.  */
+
+typedef char k5_os_nothread_mutex;
+# define K5_OS_NOTHREAD_MUTEX_PARTIAL_INITIALIZER       0
+/* Empty inline functions avoid the "statement with no effect"
+   warnings, and do better type-checking than functions that don't use
+   their arguments.  */
+static inline int k5_os_nothread_mutex_finish_init(k5_os_nothread_mutex *m) {
+    return 0;
+}
+static inline int k5_os_nothread_mutex_init(k5_os_nothread_mutex *m) {
+    return 0;
+}
+static inline int k5_os_nothread_mutex_destroy(k5_os_nothread_mutex *m) {
+    return 0;
+}
+static inline int k5_os_nothread_mutex_lock(k5_os_nothread_mutex *m) {
+    return 0;
+}
+static inline int k5_os_nothread_mutex_unlock(k5_os_nothread_mutex *m) {
+    return 0;
+}
+
+/* Values:
+   2 - function has not been run
+   3 - function has been run
+   4 - function is being run -- deadlock detected */
+typedef unsigned char k5_os_nothread_once_t;
+# define K5_OS_NOTHREAD_ONCE_INIT       2
+# define k5_os_nothread_once(O,F)                               \
+    (*(O) == 3 ? 0                                              \
+     : *(O) == 2 ? (*(O) = 4, (F)(), *(O) = 3, 0)               \
+     : (assert(*(O) != 4), assert(*(O) == 2 || *(O) == 3), 0))
+
+
+
+#ifndef ENABLE_THREADS
+
+typedef k5_os_nothread_mutex k5_os_mutex;
+# define K5_OS_MUTEX_PARTIAL_INITIALIZER        \
+    K5_OS_NOTHREAD_MUTEX_PARTIAL_INITIALIZER
+# define k5_os_mutex_finish_init        k5_os_nothread_mutex_finish_init
+# define k5_os_mutex_init               k5_os_nothread_mutex_init
+# define k5_os_mutex_destroy            k5_os_nothread_mutex_destroy
+# define k5_os_mutex_lock               k5_os_nothread_mutex_lock
+# define k5_os_mutex_unlock             k5_os_nothread_mutex_unlock
+
+# define k5_once_t                      k5_os_nothread_once_t
+# define K5_ONCE_INIT                   K5_OS_NOTHREAD_ONCE_INIT
+# define k5_once                        k5_os_nothread_once
+
+#elif HAVE_PTHREAD
+
+# include <pthread.h>
+
+/* Weak reference support, etc.
+
+   Linux: Stub mutex routines exist, but pthread_once does not.
+
+   Solaris <10: In libc there's a pthread_once that doesn't seem to do
+   anything.  Bleah.  But pthread_mutexattr_setrobust_np is defined
+   only in libpthread.  However, some version of GNU libc (Red Hat's
+   Fedora Core 5, reportedly) seems to have that function, but no
+   declaration, so we'd have to declare it in order to test for its
+   address.  We now have tests to see if pthread_once actually works,
+   so stick with that for now.
+
+   Solaris 10: The real thread support now lives in libc, and
+   libpthread is just a filter object.  So we might as well use the
+   real functions unconditionally.  Since we haven't got a test for
+   this property yet, we use NO_WEAK_PTHREADS defined in aclocal.m4
+   depending on the OS type.
+
+   IRIX 6.5 stub pthread support in libc is really annoying.  The
+   pthread_mutex_lock function returns ENOSYS for a program not linked
+   against -lpthread.  No link-time failure, no weak symbols, etc.
+   The C library doesn't provide pthread_once; we can use weak
+   reference support for that.
+
+   If weak references are not available, then for now, we assume that
+   the pthread support routines will always be available -- either the
+   real thing, or functional stubs that merely prohibit creating
+   threads.
+
+   If we find a platform with non-functional stubs and no weak
+   references, we may have to resort to some hack like dlsym on the
+   symbol tables of the current process.  */
+
+#if defined(HAVE_PRAGMA_WEAK_REF) && !defined(NO_WEAK_PTHREADS)
+# define USE_CONDITIONAL_PTHREADS
+#endif
+
+#ifdef USE_CONDITIONAL_PTHREADS
+
+/* Can't rely on useful stubs -- see above regarding Solaris.  */
+typedef struct {
+    pthread_once_t o;
+    k5_os_nothread_once_t n;
+} k5_once_t;
+# define K5_ONCE_INIT   { PTHREAD_ONCE_INIT, K5_OS_NOTHREAD_ONCE_INIT }
+
+int k5_once(k5_once_t *once, void (*fn)(void));
+#else
+
+/* no pragma weak support */
+
+typedef pthread_once_t k5_once_t;
+# define K5_ONCE_INIT   PTHREAD_ONCE_INIT
+# define k5_once        pthread_once
+
+#endif
+
+#if defined(__mips) && defined(__sgi) && (defined(_SYSTYPE_SVR4) || defined(__SYSTYPE_SVR4__))
+# ifndef HAVE_PRAGMA_WEAK_REF
+#  if defined(__GNUC__) && __GNUC__ < 3
+#   error "Please update to a newer gcc with weak symbol support, or switch to native cc, reconfigure and recompile."
+#  else
+#   error "Weak reference support is required"
+#  endif
+# endif
+#endif
+
+typedef pthread_mutex_t k5_os_mutex;
+# define K5_OS_MUTEX_PARTIAL_INITIALIZER        \
+    PTHREAD_MUTEX_INITIALIZER
+
+#ifdef USE_CONDITIONAL_PTHREADS
+
+# define k5_os_mutex_finish_init(M)             (0)
+int k5_os_mutex_init(k5_os_mutex *m);
+int k5_os_mutex_destroy(k5_os_mutex *m);
+int k5_os_mutex_lock(k5_os_mutex *m);
+int k5_os_mutex_unlock(k5_os_mutex *m);
+
+#else
+
+static inline int k5_os_mutex_finish_init(k5_os_mutex *m) { return 0; }
+# define k5_os_mutex_init(M)            pthread_mutex_init((M), 0)
+# define k5_os_mutex_destroy(M)         pthread_mutex_destroy((M))
+# define k5_os_mutex_lock(M)            pthread_mutex_lock(M)
+# define k5_os_mutex_unlock(M)          pthread_mutex_unlock(M)
+
+#endif /* is pthreads always available? */
+
+#elif defined _WIN32
+
+# define k5_once_t k5_os_nothread_once_t
+
+typedef struct {
+    HANDLE h;
+    int is_locked;
+} k5_os_mutex;
+
+# define K5_OS_MUTEX_PARTIAL_INITIALIZER { INVALID_HANDLE_VALUE, 0 }
+
+# define k5_os_mutex_finish_init(M)                                     \
+    (assert((M)->h == INVALID_HANDLE_VALUE),                            \
+     ((M)->h = CreateMutex(NULL, FALSE, NULL)) ? 0 : GetLastError())
+# define k5_os_mutex_init(M)                                            \
+    ((M)->is_locked = 0,                                                \
+     ((M)->h = CreateMutex(NULL, FALSE, NULL)) ? 0 : GetLastError())
+# define k5_os_mutex_destroy(M)                                 \
+    (CloseHandle((M)->h) ? ((M)->h = 0, 0) : GetLastError())
+# define k5_os_mutex_lock k5_win_mutex_lock
+
+static inline int k5_win_mutex_lock(k5_os_mutex *m)
+{
+    DWORD res;
+    res = WaitForSingleObject(m->h, INFINITE);
+    if (res == WAIT_FAILED)
+        return GetLastError();
+    /* Eventually these should be turned into some reasonable error
+       code.  */
+    assert(res != WAIT_TIMEOUT);
+    assert(res != WAIT_ABANDONED);
+    assert(res == WAIT_OBJECT_0);
+    /* Avoid locking twice.  */
+    assert(m->is_locked == 0);
+    m->is_locked = 1;
+    return 0;
+}
+
+# define k5_os_mutex_unlock(M)                  \
+    (assert((M)->is_locked == 1),               \
+     (M)->is_locked = 0,                        \
+     ReleaseMutex((M)->h) ? 0 : GetLastError())
+
+#else
+
+# error "Thread support enabled, but thread system unknown"
+
+#endif
+
+typedef k5_os_mutex k5_mutex_t;
+#define K5_MUTEX_PARTIAL_INITIALIZER    K5_OS_MUTEX_PARTIAL_INITIALIZER
+static inline int k5_mutex_init(k5_mutex_t *m)
+{
+    return k5_os_mutex_init(m);
+}
+static inline int k5_mutex_finish_init(k5_mutex_t *m)
+{
+    return k5_os_mutex_finish_init(m);
+}
+#define k5_mutex_destroy(M)                     \
+    (k5_os_mutex_destroy(M))
+
+static inline void k5_mutex_lock(k5_mutex_t *m)
+{
+    int r = k5_os_mutex_lock(m);
+#ifndef NDEBUG
+    if (r != 0) {
+        fprintf(stderr, "k5_mutex_lock: Received error %d (%s)\n",
+                r, strerror(r));
+    }
+#endif
+    assert(r == 0);
+}
+
+static inline void k5_mutex_unlock(k5_mutex_t *m)
+{
+    int r = k5_os_mutex_unlock(m);
+#ifndef NDEBUG
+    if (r != 0) {
+        fprintf(stderr, "k5_mutex_unlock: Received error %d (%s)\n",
+                r, strerror(r));
+    }
+#endif
+    assert(r == 0);
+}
+
+#define k5_mutex_assert_locked(M)       ((void)(M))
+#define k5_mutex_assert_unlocked(M)     ((void)(M))
+#define k5_assert_locked        k5_mutex_assert_locked
+#define k5_assert_unlocked      k5_mutex_assert_unlocked
+
+/* Thread-specific data; implemented in a support file, because we'll
+   need to keep track of some global data for cleanup purposes.
+
+   Note that the callback function type is such that the C library
+   routine free() is a valid callback.  */
+typedef enum {
+    K5_KEY_COM_ERR,
+    K5_KEY_GSS_KRB5_SET_CCACHE_OLD_NAME,
+    K5_KEY_GSS_KRB5_CCACHE_NAME,
+    K5_KEY_GSS_KRB5_ERROR_MESSAGE,
+    K5_KEY_GSS_SPNEGO_STATUS,
+#if defined(__MACH__) && defined(__APPLE__)
+    K5_KEY_IPC_CONNECTION_INFO,
+#endif
+    K5_KEY_MAX
+} k5_key_t;
+/* rename shorthand symbols for export */
+#define k5_key_register krb5int_key_register
+#define k5_getspecific  krb5int_getspecific
+#define k5_setspecific  krb5int_setspecific
+#define k5_key_delete   krb5int_key_delete
+extern int k5_key_register(k5_key_t, void (*)(void *));
+extern void *k5_getspecific(k5_key_t);
+extern int k5_setspecific(k5_key_t, void *);
+extern int k5_key_delete(k5_key_t);
+
+extern int  KRB5_CALLCONV krb5int_mutex_alloc  (k5_mutex_t **);
+extern void KRB5_CALLCONV krb5int_mutex_free   (k5_mutex_t *);
+extern void KRB5_CALLCONV krb5int_mutex_lock   (k5_mutex_t *);
+extern void KRB5_CALLCONV krb5int_mutex_unlock (k5_mutex_t *);
+
+/* In time, many of the definitions above should move into the support
+   library, and this file should be greatly simplified.  For type
+   definitions, that'll take some work, since other data structures
+   incorporate mutexes directly, and our mutex type is dependent on
+   configuration options and system attributes.  For most functions,
+   though, it should be relatively easy.
+
+   For now, plugins should use the exported functions, and not the
+   above macros, and use krb5int_mutex_alloc for allocations.  */
+#if defined(PLUGIN) || (defined(CONFIG_SMALL) && !defined(THREAD_SUPPORT_IMPL))
+#undef k5_mutex_lock
+#define k5_mutex_lock krb5int_mutex_lock
+#undef k5_mutex_unlock
+#define k5_mutex_unlock krb5int_mutex_unlock
+#endif
+
+#endif /* multiple inclusion? */

--- a/auth/kinit_client/k5-trace.h
+++ b/auth/kinit_client/k5-trace.h
@@ -1,0 +1,523 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-trace.h */
+/*
+ * Copyright (C) 2010 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/*
+ * This header contains trace macro definitions, which map trace points within
+ * the code to krb5int_trace() calls with descriptive text strings.
+ *
+ * A new trace macro must be defined in this file for each new location to
+ * be traced; the TRACE() macro should never be used directly.  This keeps
+ * the tracing logic centralized in one place, to facilitate integration with
+ * alternate tracing backends such as DTrace.
+ *
+ * Trace logging is intended to aid power users in diagnosing configuration
+ * problems by showing what's going on behind the scenes of complex operations.
+ * Although trace logging is sometimes useful to developers, it is not intended
+ * as a replacement for a debugger, and it is not desirable to drown the user
+ * in output.  Observe the following guidelines when adding trace points:
+ *
+ *   - Avoid mentioning function or variable names in messages.
+ *
+ *   - Try to convey what decisions are being made and what external inputs
+ *     they are based on, not the process of making decisions.
+ *
+ *   - It is generally not necessary to trace before returning an unrecoverable
+ *     error.  If an error code is unclear by itself, make it clearer with
+ *     krb5_set_error_message().
+ *
+ *   - Keep macros simple.  Add format specifiers to krb5int_trace's formatter
+ *     as necessary (and document them here) instead of transforming macro
+ *     arguments.
+ *
+ *   - Like printf, the trace formatter interface is not type-safe.  Check your
+ *     formats carefully.  Cast integral arguments to the appropriate type if
+ *     they do not already patch.
+ *
+ * The following specifiers are supported by the formatter (see the
+ * implementation in lib/krb5/os/trace.c for details):
+ *
+ *   {int}         int, in decimal
+ *   {long}        long, in decimal
+ *   {str}         const char *, display as C string
+ *   {lenstr}      size_t and const char *, as a counted string
+ *   {hexlenstr}   size_t and const char *, as hex bytes
+ *   {hashlenstr}  size_t and const char *, as four-character hex hash
+ *   {raddr}       struct remote_address *, show socket type, address, port
+ *   {data}        krb5_data *, display as counted string
+ *   {hexdata}     krb5_data *, display as hex bytes
+ *   {errno}       int, display as number/errorstring
+ *   {kerr}        krb5_error_code, display as number/errorstring
+ *   {keyblock}    const krb5_keyblock *, display enctype and hash of key
+ *   {key}         krb5_key, display enctype and hash of key
+ *   {cksum}       const krb5_checksum *, display cksumtype and hex checksum
+ *   {princ}       krb5_principal, unparse and display
+ *   {ptype}       krb5_int32, krb5_principal type, display name
+ *   {patype}      krb5_preauthtype, a single padata type number
+ *   {patypes}     krb5_pa_data **, display list of padata type numbers
+ *   {etype}       krb5_enctype, display shortest name of enctype
+ *   {etypes}      krb5_enctype *, display list of enctypes
+ *   {ccache}      krb5_ccache, display type:name
+ *   {keytab}      krb5_keytab, display name
+ *   {creds}       krb5_creds *, display clientprinc -> serverprinc
+ */
+
+#ifndef K5_TRACE_H
+#define K5_TRACE_H
+
+#ifdef DISABLE_TRACING
+#define TRACE(ctx, ...)
+#else
+
+void krb5int_trace(krb5_context context, const char *fmt, ...);
+
+/* Try to optimize away argument evaluation and function call when we're not
+ * tracing, if this source file knows the internals of the context. */
+#ifdef _KRB5_INT_H
+#define TRACE(ctx, ...)                                        \
+    do { if (ctx->trace_callback != NULL)                      \
+            krb5int_trace(ctx, __VA_ARGS__); } while (0)
+#else
+#define TRACE(ctx, ...) krb5int_trace(ctx, __VA_ARGS__)
+#endif
+
+#endif /* DISABLE_TRACING */
+
+#define TRACE_CC_CACHE_MATCH(c, princ, ret)                             \
+    TRACE(c, "Matching {princ} in collection with result: {kerr}",      \
+          princ, ret)
+#define TRACE_CC_DESTROY(c, cache)                      \
+    TRACE(c, "Destroying ccache {ccache}", cache)
+#define TRACE_CC_GEN_NEW(c, cache)                                      \
+    TRACE(c, "Generating new unique ccache based on {ccache}", cache)
+#define TRACE_CC_GET_CONFIG(c, cache, princ, key, data)             \
+    TRACE(c, "Read config in {ccache} for {princ}: {str}: {data}",  \
+          cache, princ, key, data)
+#define TRACE_CC_INIT(c, cache, princ)                              \
+    TRACE(c, "Initializing {ccache} with default princ {princ}",    \
+          cache, princ)
+#define TRACE_CC_MOVE(c, src, dst)                                      \
+    TRACE(c, "Moving ccache {ccache} to {ccache}", src, dst)
+#define TRACE_CC_NEW_UNIQUE(c, type)                            \
+    TRACE(c, "Resolving unique ccache of type {str}", type)
+#define TRACE_CC_REMOVE(c, cache, creds)                        \
+    TRACE(c, "Removing {creds} from {ccache}", creds, cache)
+#define TRACE_CC_RETRIEVE(c, cache, creds, ret)                      \
+    TRACE(c, "Retrieving {creds} from {ccache} with result: {kerr}", \
+              creds, cache, ret)
+#define TRACE_CC_RETRIEVE_REF(c, cache, creds, ret)                     \
+    TRACE(c, "Retrying {creds} with result: {kerr}", creds, ret)
+#define TRACE_CC_SET_CONFIG(c, cache, princ, key, data)               \
+    TRACE(c, "Storing config in {ccache} for {princ}: {str}: {data}", \
+          cache, princ, key, data)
+#define TRACE_CC_STORE(c, cache, creds)                         \
+    TRACE(c, "Storing {creds} in {ccache}", creds, cache)
+#define TRACE_CC_STORE_TKT(c, cache, creds)                     \
+    TRACE(c, "Also storing {creds} based on ticket", creds)
+
+#define TRACE_CCSELECT_VTINIT_FAIL(c, ret)                              \
+    TRACE(c, "ccselect module failed to init vtable: {kerr}", ret)
+#define TRACE_CCSELECT_INIT_FAIL(c, name, ret)                          \
+    TRACE(c, "ccselect module {str} failed to init: {kerr}", name, ret)
+#define TRACE_CCSELECT_MODCHOICE(c, name, server, cache, princ)         \
+    TRACE(c, "ccselect module {str} chose cache {ccache} with client "  \
+          "principal {princ} for server principal {princ}", name, cache, \
+          princ, server)
+#define TRACE_CCSELECT_MODNOTFOUND(c, name, server, princ)              \
+    TRACE(c, "ccselect module {str} chose client principal {princ} "    \
+          "for server principal {princ} but found no cache", name, princ, \
+          server)
+#define TRACE_CCSELECT_MODFAIL(c, name, ret, server)                  \
+    TRACE(c, "ccselect module {str} yielded error {kerr} for server " \
+          "principal {princ}", name, ret, server)
+#define TRACE_CCSELECT_NOTFOUND(c, server)                          \
+    TRACE(c, "ccselect can't find appropriate cache for server "    \
+          "principal {princ}", server)
+#define TRACE_CCSELECT_DEFAULT(c, cache, server)                    \
+    TRACE(c, "ccselect choosing default cache {ccache} for server " \
+          "principal {princ}", cache, server)
+
+#define TRACE_DNS_SRV_ANS(c, host, port, prio, weight)                \
+    TRACE(c, "SRV answer: {int} {int} {int} \"{str}\"", prio, weight, \
+          port, host)
+#define TRACE_DNS_SRV_NOTFOUND(c)               \
+    TRACE(c, "No SRV records found")
+#define TRACE_DNS_SRV_SEND(c, domain)                   \
+    TRACE(c, "Sending DNS SRV query for {str}", domain)
+#define TRACE_DNS_URI_ANS(c, uri, prio, weight)                         \
+    TRACE(c, "URI answer: {int} {int} \"{str}\"", prio, weight, uri)
+#define TRACE_DNS_URI_NOTFOUND(c)               \
+    TRACE(c, "No URI records found")
+#define TRACE_DNS_URI_SEND(c, domain)                   \
+    TRACE(c, "Sending DNS URI query for {str}", domain)
+
+#define TRACE_FAST_ARMOR_CCACHE(c, ccache_name)         \
+    TRACE(c, "FAST armor ccache: {str}", ccache_name)
+#define TRACE_FAST_ARMOR_CCACHE_KEY(c, keyblock)                \
+    TRACE(c, "Armor ccache session key: {keyblock}", keyblock)
+#define TRACE_FAST_ARMOR_KEY(c, keyblock)               \
+    TRACE(c, "FAST armor key: {keyblock}", keyblock)
+#define TRACE_FAST_CCACHE_CONFIG(c)                                     \
+    TRACE(c, "Using FAST due to armor ccache negotiation result")
+#define TRACE_FAST_DECODE(c)                    \
+    TRACE(c, "Decoding FAST response")
+#define TRACE_FAST_ENCODE(c)                                            \
+    TRACE(c, "Encoding request body and padata into FAST request")
+#define TRACE_FAST_NEGO(c, avail)                                       \
+    TRACE(c, "FAST negotiation: {str}available", (avail) ? "" : "un")
+#define TRACE_FAST_PADATA_UPGRADE(c)                                    \
+    TRACE(c, "Upgrading to FAST due to presence of PA_FX_FAST in reply")
+#define TRACE_FAST_REPLY_KEY(c, keyblock)                       \
+    TRACE(c, "FAST reply key: {keyblock}", keyblock)
+#define TRACE_FAST_REQUIRED(c)                                  \
+    TRACE(c, "Using FAST due to KRB5_FAST_REQUIRED flag")
+
+#define TRACE_GET_CREDS_FALLBACK(c, hostname)                           \
+    TRACE(c, "Falling back to canonicalized server hostname {str}", hostname)
+
+#define TRACE_GIC_PWD_CHANGED(c)                                \
+    TRACE(c, "Getting initial TGT with changed password")
+#define TRACE_GIC_PWD_CHANGEPW(c, tries)                                \
+    TRACE(c, "Attempting password change; {int} tries remaining", tries)
+#define TRACE_GIC_PWD_EXPIRED(c)                                \
+    TRACE(c, "Principal expired; getting changepw ticket")
+#define TRACE_GIC_PWD_PRIMARY(c)                        \
+    TRACE(c, "Retrying AS request with primary KDC")
+
+#define TRACE_GSS_CLIENT_KEYTAB_FAIL(c, ret)                            \
+    TRACE(c, "Unable to resolve default client keytab: {kerr}", ret)
+
+#define TRACE_ENCTYPE_LIST_UNKNOWN(c, profvar, name)                    \
+    TRACE(c, "Unrecognized enctype name in {str}: {str}", profvar, name)
+
+#define TRACE_HOSTREALM_VTINIT_FAIL(c, ret)                             \
+    TRACE(c, "hostrealm module failed to init vtable: {kerr}", ret)
+#define TRACE_HOSTREALM_INIT_FAIL(c, name, ret)                         \
+    TRACE(c, "hostrealm module {str} failed to init: {kerr}", name, ret)
+
+#define TRACE_INIT_CREDS(c, princ)                              \
+    TRACE(c, "Getting initial credentials for {princ}", princ)
+#define TRACE_INIT_CREDS_AS_KEY_GAK(c, keyblock)                        \
+    TRACE(c, "AS key obtained from gak_fct: {keyblock}", keyblock)
+#define TRACE_INIT_CREDS_AS_KEY_PREAUTH(c, keyblock)                    \
+    TRACE(c, "AS key determined by preauth: {keyblock}", keyblock)
+#define TRACE_INIT_CREDS_DECRYPTED_REPLY(c, keyblock)                   \
+    TRACE(c, "Decrypted AS reply; session key is: {keyblock}", keyblock)
+#define TRACE_INIT_CREDS_ERROR_REPLY(c, code)           \
+    TRACE(c, "Received error from KDC: {kerr}", code)
+#define TRACE_INIT_CREDS_GAK(c, salt, s2kparams)                    \
+    TRACE(c, "Getting AS key, salt \"{data}\", params \"{data}\"",  \
+          salt, s2kparams)
+#define TRACE_INIT_CREDS_IDENTIFIED_REALM(c, realm)                     \
+    TRACE(c, "Identified realm of client principal as {data}", realm)
+#define TRACE_INIT_CREDS_KEYTAB_LOOKUP(c, princ, etypes)                \
+    TRACE(c, "Found entries for {princ} in keytab: {etypes}", princ, etypes)
+#define TRACE_INIT_CREDS_KEYTAB_LOOKUP_FAILED(c, code)          \
+    TRACE(c, "Couldn't lookup etypes in keytab: {kerr}", code)
+#define TRACE_INIT_CREDS_PREAUTH(c)                     \
+    TRACE(c, "Preauthenticating using KDC method data")
+#define TRACE_INIT_CREDS_PREAUTH_DECRYPT_FAIL(c, code)                  \
+    TRACE(c, "Decrypt with preauth AS key failed: {kerr}", code)
+#define TRACE_INIT_CREDS_PREAUTH_MORE(c, patype)                \
+    TRACE(c, "Continuing preauth mech {patype}", patype)
+#define TRACE_INIT_CREDS_PREAUTH_NONE(c)        \
+    TRACE(c, "Sending unauthenticated request")
+#define TRACE_INIT_CREDS_PREAUTH_OPTIMISTIC(c)  \
+    TRACE(c, "Attempting optimistic preauth")
+#define TRACE_INIT_CREDS_PREAUTH_TRYAGAIN(c, patype, code)              \
+    TRACE(c, "Recovering from KDC error {int} using preauth mech {patype}", \
+          patype, (int)code)
+#define TRACE_INIT_CREDS_RESTART_FAST(c)        \
+    TRACE(c, "Restarting to upgrade to FAST")
+#define TRACE_INIT_CREDS_RESTART_PREAUTH_FAILED(c)                      \
+    TRACE(c, "Restarting due to PREAUTH_FAILED from FAST negotiation")
+#define TRACE_INIT_CREDS_REFERRAL(c, realm)                     \
+    TRACE(c, "Following referral to realm {data}", realm)
+#define TRACE_INIT_CREDS_RETRY_TCP(c)                                   \
+    TRACE(c, "Request or response is too big for UDP; retrying with TCP")
+#define TRACE_INIT_CREDS_SALT_PRINC(c, salt)                    \
+    TRACE(c, "Salt derived from principal: {data}", salt)
+#define TRACE_INIT_CREDS_SERVICE(c, service)                    \
+    TRACE(c, "Setting initial creds service to {str}", service)
+
+#define TRACE_KADM5_AUTH_VTINIT_FAIL(c, ret)                            \
+    TRACE(c, "kadm5_auth module failed to init vtable: {kerr}", ret)
+#define TRACE_KADM5_AUTH_INIT_FAIL(c, name, ret)                        \
+    TRACE(c, "kadm5_auth module {str} failed to init: {kerr}", ret)
+#define TRACE_KADM5_AUTH_INIT_SKIP(c, name)                             \
+    TRACE(c, "kadm5_auth module {str} declined to initialize", name)
+
+#define TRACE_KT_GET_ENTRY(c, keytab, princ, vno, enctype, err)         \
+    TRACE(c, "Retrieving {princ} from {keytab} (vno {int}, enctype {etype}) " \
+          "with result: {kerr}", princ, keytab, (int) vno, enctype, err)
+
+#define TRACE_LOCALAUTH_INIT_CONFLICT(c, type, oldname, newname)        \
+    TRACE(c, "Ignoring localauth module {str} because it conflicts "    \
+          "with an2ln type {str} from module {str}", newname, type, oldname)
+#define TRACE_LOCALAUTH_VTINIT_FAIL(c, ret)                             \
+    TRACE(c, "localauth module failed to init vtable: {kerr}", ret)
+#define TRACE_LOCALAUTH_INIT_FAIL(c, name, ret)                         \
+    TRACE(c, "localauth module {str} failed to init: {kerr}", name, ret)
+
+#define TRACE_MK_REP(c, ctime, cusec, subkey, seqnum)                   \
+    TRACE(c, "Creating AP-REP, time {long}.{int}, subkey {keyblock}, "  \
+          "seqnum {int}", (long) ctime, (int) cusec, subkey, (int) seqnum)
+
+#define TRACE_MK_REQ(c, creds, seqnum, subkey, sesskeyblock)            \
+    TRACE(c, "Creating authenticator for {creds}, seqnum {int}, "       \
+          "subkey {key}, session key {keyblock}", creds, (int) seqnum,  \
+          subkey, sesskeyblock)
+#define TRACE_MK_REQ_ETYPES(c, etypes)                                  \
+    TRACE(c, "Negotiating for enctypes in authenticator: {etypes}", etypes)
+
+#define TRACE_MSPAC_VERIFY_FAIL(c, err)                         \
+    TRACE(c, "PAC checksum verification failed: {kerr}", err)
+#define TRACE_MSPAC_DISCARD_UNVERF(c)           \
+    TRACE(c, "Filtering out unverified MS PAC")
+
+#define TRACE_NEGOEX_INCOMING(c, seqnum, typestr, info)                 \
+    TRACE(c, "NegoEx received [{int}]{str}: {str}", (int)seqnum, typestr, info)
+#define TRACE_NEGOEX_OUTGOING(c, seqnum, typestr, info)                 \
+    TRACE(c, "NegoEx sending [{int}]{str}: {str}", (int)seqnum, typestr, info)
+
+#define TRACE_PLUGIN_LOAD_FAIL(c, modname, err)                         \
+    TRACE(c, "Error loading plugin module {str}: {kerr}", modname, err)
+#define TRACE_PLUGIN_LOOKUP_FAIL(c, modname, err)                       \
+    TRACE(c, "Error initializing module {str}: {kerr}", modname, err)
+
+#define TRACE_PREAUTH_CONFLICT(c, name1, name2, patype)                 \
+    TRACE(c, "Preauth module {str} conflicts with module {str} for pa " \
+          "type {patype}", name1, name2, patype)
+#define TRACE_PREAUTH_COOKIE(c, len, data)                      \
+    TRACE(c, "Received cookie: {lenstr}", (size_t) len, data)
+#define TRACE_PREAUTH_ENC_TS_KEY_GAK(c, keyblock)                       \
+    TRACE(c, "AS key obtained for encrypted timestamp: {keyblock}", keyblock)
+#define TRACE_PREAUTH_ENC_TS(c, sec, usec, plain, enc)                  \
+    TRACE(c, "Encrypted timestamp (for {long}.{int}): plain {hexdata}, " \
+          "encrypted {hexdata}", (long) sec, (int) usec, plain, enc)
+#define TRACE_PREAUTH_ENC_TS_DISABLED(c)                                \
+    TRACE(c, "Ignoring encrypted timestamp because it is disabled")
+#define TRACE_PREAUTH_ETYPE_INFO(c, etype, salt, s2kparams)          \
+    TRACE(c, "Selected etype info: etype {etype}, salt \"{data}\", " \
+          "params \"{data}\"", etype, salt, s2kparams)
+#define TRACE_PREAUTH_INFO_FAIL(c, patype, code)                        \
+    TRACE(c, "Preauth builtin info function failure, type={patype}: {kerr}", \
+          patype, code)
+#define TRACE_PREAUTH_INPUT(c, padata)                          \
+    TRACE(c, "Processing preauth types: {patypes}", padata)
+#define TRACE_PREAUTH_OUTPUT(c, padata)                                 \
+    TRACE(c, "Produced preauth for next request: {patypes}", padata)
+#define TRACE_PREAUTH_PROCESS(c, name, patype, real, code)              \
+    TRACE(c, "Preauth module {str} ({int}) ({str}) returned: "          \
+          "{kerr}", name, (int) patype, real ? "real" : "info", code)
+#define TRACE_PREAUTH_SAM_KEY_GAK(c, keyblock)                  \
+    TRACE(c, "AS key obtained for SAM: {keyblock}", keyblock)
+#define TRACE_PREAUTH_SALT(c, salt, patype)                          \
+    TRACE(c, "Received salt \"{data}\" via padata type {patype}", salt, \
+          patype)
+#define TRACE_PREAUTH_SKIP(c, name, patype)                           \
+    TRACE(c, "Skipping previously used preauth module {str} ({int})", \
+          name, (int) patype)
+#define TRACE_PREAUTH_TRYAGAIN_INPUT(c, patype, padata)                 \
+    TRACE(c, "Preauth tryagain input types ({int}): {patypes}", patype, padata)
+#define TRACE_PREAUTH_TRYAGAIN(c, name, patype, code)                   \
+    TRACE(c, "Preauth module {str} ({int}) tryagain returned: {kerr}",  \
+          name, (int)patype, code)
+#define TRACE_PREAUTH_TRYAGAIN_OUTPUT(c, padata)                        \
+    TRACE(c, "Followup preauth for next request: {patypes}", padata)
+#define TRACE_PREAUTH_WRONG_CONTEXT(c)                                  \
+    TRACE(c, "Wrong context passed to krb5_init_creds_free(); leaking " \
+          "modreq objects")
+
+#define TRACE_PROFILE_ERR(c,subsection, section, retval)             \
+    TRACE(c, "Bad value of {str} from [{str}] in conf file: {kerr}", \
+          subsection, section, retval)
+
+#define TRACE_RD_REP(c, ctime, cusec, subkey, seqnum)               \
+    TRACE(c, "Read AP-REP, time {long}.{int}, subkey {keyblock}, "      \
+          "seqnum {int}", (long) ctime, (int) cusec, subkey, (int) seqnum)
+#define TRACE_RD_REP_DCE(c, ctime, cusec, seqnum)                      \
+    TRACE(c, "Read DCE-style AP-REP, time {long}.{int}, seqnum {int}", \
+          (long) ctime, (int) cusec, (int) seqnum)
+
+#define TRACE_RD_REQ_DECRYPT_ANY(c, princ, keyblock)                \
+    TRACE(c, "Decrypted AP-REQ with server principal {princ}: "     \
+          "{keyblock}", princ, keyblock)
+#define TRACE_RD_REQ_DECRYPT_SPECIFIC(c, princ, keyblock)               \
+    TRACE(c, "Decrypted AP-REQ with specified server principal {princ}: " \
+          "{keyblock}", princ, keyblock)
+#define TRACE_RD_REQ_DECRYPT_FAIL(c, err)                       \
+    TRACE(c, "Failed to decrypt AP-REQ ticket: {kerr}", err)
+#define TRACE_RD_REQ_NEGOTIATED_ETYPE(c, etype)                     \
+    TRACE(c, "Negotiated enctype based on authenticator: {etype}",  \
+          etype)
+#define TRACE_RD_REQ_SUBKEY(c, keyblock)                                \
+    TRACE(c, "Authenticator contains subkey: {keyblock}", keyblock)
+#define TRACE_RD_REQ_TICKET(c, client, server, keyblock)                \
+    TRACE(c, "AP-REQ ticket: {princ} -> {princ}, session key {keyblock}", \
+          client, server, keyblock)
+
+#define TRACE_SENDTO_KDC_ERROR_SET_MESSAGE(c, raddr, err)               \
+    TRACE(c, "Error preparing message to send to {raddr}: {errno}",     \
+          raddr, err)
+#define TRACE_SENDTO_KDC(c, len, rlm, primary, tcp)                     \
+    TRACE(c, "Sending request ({int} bytes) to {data}{str}{str}", len,  \
+          rlm, (primary) ? " (primary)" : "", (tcp) ? " (tcp only)" : "")
+#define TRACE_SENDTO_KDC_K5TLS_LOAD_ERROR(c, ret)       \
+    TRACE(c, "Error loading k5tls module: {kerr}", ret)
+#define TRACE_SENDTO_KDC_PRIMARY(c, primary)                            \
+    TRACE(c, "Response was{str} from primary KDC", (primary) ? "" : " not")
+#define TRACE_SENDTO_KDC_RESOLVING(c, hostname)         \
+    TRACE(c, "Resolving hostname {str}", hostname)
+#define TRACE_SENDTO_KDC_RESPONSE(c, len, raddr)                        \
+    TRACE(c, "Received answer ({int} bytes) from {raddr}", len, raddr)
+#define TRACE_SENDTO_KDC_HTTPS_ERROR_CONNECT(c, raddr)          \
+    TRACE(c, "HTTPS error connecting to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_HTTPS_ERROR_RECV(c, raddr)             \
+    TRACE(c, "HTTPS error receiving from {raddr}", raddr)
+#define TRACE_SENDTO_KDC_HTTPS_ERROR_SEND(c, raddr)     \
+    TRACE(c, "HTTPS error sending to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_HTTPS_SEND(c, raddr)                           \
+    TRACE(c, "Sending HTTPS request to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_HTTPS_ERROR(c, errs)                           \
+    TRACE(c, "HTTPS error: {str}", errs)
+#define TRACE_SENDTO_KDC_TCP_CONNECT(c, raddr)                  \
+    TRACE(c, "Initiating TCP connection to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_TCP_DISCONNECT(c, raddr)               \
+    TRACE(c, "Terminating TCP connection to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_TCP_ERROR_CONNECT(c, raddr, err)               \
+    TRACE(c, "TCP error connecting to {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_TCP_ERROR_RECV(c, raddr, err)                  \
+    TRACE(c, "TCP error receiving from {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_TCP_ERROR_RECV_LEN(c, raddr, err)              \
+    TRACE(c, "TCP error receiving from {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_TCP_ERROR_SEND(c, raddr, err)                  \
+    TRACE(c, "TCP error sending to {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_TCP_SEND(c, raddr)             \
+    TRACE(c, "Sending TCP request to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_UDP_ERROR_RECV(c, raddr, err)                  \
+    TRACE(c, "UDP error receiving from {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_UDP_ERROR_SEND_INITIAL(c, raddr, err)          \
+    TRACE(c, "UDP error sending to {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_UDP_ERROR_SEND_RETRY(c, raddr, err)            \
+    TRACE(c, "UDP error sending to {raddr}: {errno}", raddr, err)
+#define TRACE_SENDTO_KDC_UDP_SEND_INITIAL(c, raddr)             \
+    TRACE(c, "Sending initial UDP request to {raddr}", raddr)
+#define TRACE_SENDTO_KDC_UDP_SEND_RETRY(c, raddr)               \
+    TRACE(c, "Sending retry UDP request to {raddr}", raddr)
+
+#define TRACE_SEND_TGS_ETYPES(c, etypes)                                \
+    TRACE(c, "etypes requested in TGS request: {etypes}", etypes)
+#define TRACE_SEND_TGS_SUBKEY(c, keyblock)                              \
+    TRACE(c, "Generated subkey for TGS request: {keyblock}", keyblock)
+
+#define TRACE_TGS_REPLY(c, client, server, keyblock)                 \
+    TRACE(c, "TGS reply is for {princ} -> {princ} with session key " \
+          "{keyblock}", client, server, keyblock)
+#define TRACE_TGS_REPLY_DECODE_SESSION(c, keyblock)                     \
+    TRACE(c, "TGS reply didn't decode with subkey; trying session key " \
+          "({keyblock)}", keyblock)
+
+#define TRACE_TLS_ERROR(c, errs)                \
+    TRACE(c, "TLS error: {str}", errs)
+#define TRACE_TLS_NO_REMOTE_CERTIFICATE(c)              \
+    TRACE(c, "TLS server certificate not received")
+#define TRACE_TLS_CERT_ERROR(c, depth, namelen, name, err, errs)        \
+    TRACE(c, "TLS certificate error at {int} ({lenstr}): {int} ({str})", \
+          depth, namelen, name, err, errs)
+#define TRACE_TLS_SERVER_NAME_MISMATCH(c, hostname)                     \
+    TRACE(c, "TLS certificate name mismatch: server certificate is "    \
+          "not for \"{str}\"", hostname)
+#define TRACE_TLS_SERVER_NAME_MATCH(c, hostname)                        \
+    TRACE(c, "TLS certificate name matched \"{str}\"", hostname)
+
+#define TRACE_TKT_CREDS(c, creds, cache)                            \
+    TRACE(c, "Getting credentials {creds} using ccache {ccache}",   \
+          creds, cache)
+#define TRACE_TKT_CREDS_ADVANCE(c, realm)                               \
+    TRACE(c, "Received TGT for {data}; advancing current realm", realm)
+#define TRACE_TKT_CREDS_CACHED_INTERMEDIATE_TGT(c, tgt)                 \
+    TRACE(c, "Found cached TGT for intermediate realm: {creds}", tgt)
+#define TRACE_TKT_CREDS_CACHED_SERVICE_TGT(c, tgt)                      \
+    TRACE(c, "Found cached TGT for service realm: {creds}", tgt)
+#define TRACE_TKT_CREDS_CLOSER_REALM(c, realm)                  \
+    TRACE(c, "Trying next closer realm in path: {data}", realm)
+#define TRACE_TKT_CREDS_COMPLETE(c, princ)                              \
+    TRACE(c, "Received creds for desired service {princ}", princ)
+#define TRACE_TKT_CREDS_FALLBACK(c, realm)                              \
+    TRACE(c, "Local realm referral failed; trying fallback realm {data}", \
+          realm)
+#define TRACE_TKT_CREDS_LOCAL_TGT(c, tgt)                               \
+    TRACE(c, "Starting with TGT for client realm: {creds}", tgt)
+#define TRACE_TKT_CREDS_NON_TGT(c, princ)                            \
+    TRACE(c, "Received non-TGT referral response ({princ}); trying " \
+          "again without referrals", princ)
+#define TRACE_TKT_CREDS_OFFPATH(c, realm)                       \
+    TRACE(c, "Received TGT for offpath realm {data}", realm)
+#define TRACE_TKT_CREDS_REFERRAL(c, princ)              \
+    TRACE(c, "Following referral TGT {princ}", princ)
+#define TRACE_TKT_CREDS_REFERRAL_REALM(c, princ)                        \
+    TRACE(c, "Server has referral realm; starting with {princ}", princ)
+#define TRACE_TKT_CREDS_RESPONSE_CODE(c, code)          \
+    TRACE(c, "TGS request result: {kerr}", code)
+#define TRACE_TKT_CREDS_RETRY_TCP(c)                                    \
+    TRACE(c, "Request or response is too big for UDP; retrying with TCP")
+#define TRACE_TKT_CREDS_SAME_REALM_TGT(c, realm)                        \
+    TRACE(c, "Received TGT referral back to same realm ({data}); trying " \
+          "again without referrals", realm)
+#define TRACE_TKT_CREDS_SERVICE_REQ(c, princ, referral)                \
+    TRACE(c, "Requesting tickets for {princ}, referrals {str}", princ, \
+          (referral) ? "on" : "off")
+#define TRACE_TKT_CREDS_TARGET_TGT(c, princ)                    \
+    TRACE(c, "Received TGT for service realm: {princ}", princ)
+#define TRACE_TKT_CREDS_TARGET_TGT_OFFPATH(c, princ)            \
+    TRACE(c, "Received TGT for service realm: {princ}", princ)
+#define TRACE_TKT_CREDS_TGT_REQ(c, next, cur)                           \
+    TRACE(c, "Requesting TGT {princ} using TGT {princ}", next, cur)
+#define TRACE_TKT_CREDS_WRONG_ENCTYPE(c)                                \
+    TRACE(c, "Retrying TGS request with desired service ticket enctypes")
+
+#define TRACE_TXT_LOOKUP_NOTFOUND(c, host)              \
+    TRACE(c, "TXT record {str} not found", host)
+#define TRACE_TXT_LOOKUP_SUCCESS(c, host, realm)                \
+    TRACE(c, "TXT record {str} found: {str}", host, realm)
+
+#define TRACE_CHECK_REPLY_SERVER_DIFFERS(c, request, reply) \
+    TRACE(c, "Reply server {princ} differs from requested {princ}", \
+          reply, request)
+
+#define TRACE_GET_CRED_VIA_TKT_EXT(c, request, reply, kdcoptions) \
+    TRACE(c, "Get cred via TGT {princ} after requesting {princ} " \
+          "(canonicalize {str})", \
+          reply, request, (kdcoptions & KDC_OPT_CANONICALIZE) ? "on" : "off")
+#define TRACE_GET_CRED_VIA_TKT_EXT_RETURN(c, ret) \
+    TRACE(c, "Got cred; {kerr}", ret)
+
+#define TRACE_KDCPOLICY_VTINIT_FAIL(c, ret)                             \
+    TRACE(c, "KDC policy module failed to init vtable: {kerr}", ret)
+#define TRACE_KDCPOLICY_INIT_SKIP(c, name)                              \
+    TRACE(c, "kadm5_auth module {str} declined to initialize", name)
+
+#endif /* K5_TRACE_H */

--- a/auth/kinit_client/kinit.c
+++ b/auth/kinit_client/kinit.c
@@ -1,0 +1,653 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* clients/kinit/kinit.c - Initialize a credential cache */
+/*
+ * Copyright 1990, 2008 by the Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+#include "autoconf.h"
+#include "k5-int.h"
+#include "k5-platform.h"        /* For asprintf and getopt */
+#include <krb5.h>
+#include "extern.h"
+#include <locale.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <errno.h>
+#include <com_err.h>
+
+#ifndef _WIN32
+#define GET_PROGNAME(x) (strrchr((x), '/') ? strrchr((x), '/') + 1 : (x))
+#else
+#define GET_PROGNAME(x) max(max(strrchr((x), '/'), strrchr((x), '\\')) + 1,(x))
+#endif
+
+#ifdef HAVE_PWD_H
+#include <pwd.h>
+static char *
+get_name_from_os()
+{
+    struct passwd *pw;
+
+    pw = getpwuid(getuid());
+    return (pw != NULL) ? pw->pw_name : NULL;
+}
+#else /* HAVE_PWD_H */
+#ifdef _WIN32
+static char *
+get_name_from_os()
+{
+    static char name[1024];
+    DWORD name_size = sizeof(name);
+
+    if (GetUserName(name, &name_size)) {
+        name[sizeof(name) - 1] = '\0'; /* Just to be extra safe */
+        return name;
+    } else {
+        return NULL;
+    }
+}
+#else /* _WIN32 */
+static char *
+get_name_from_os()
+{
+    return NULL;
+}
+#endif /* _WIN32 */
+#endif /* HAVE_PWD_H */
+
+static char *progname;
+
+typedef enum { INIT_PW, INIT_KT, RENEW, VALIDATE } action_type;
+
+struct k_opts
+{
+    /* In seconds */
+    krb5_deltat starttime;
+    krb5_deltat lifetime;
+    krb5_deltat rlife;
+
+    int forwardable;
+    int proxiable;
+    int request_pac;
+    int anonymous;
+    int addresses;
+
+    int not_forwardable;
+    int not_proxiable;
+    int not_request_pac;
+    int no_addresses;
+
+    int verbose;
+
+    char *principal_name;
+    char *service_name;
+    char *keytab_name;
+    char *k5_in_cache_name;
+    char *k5_out_cache_name;
+    char *armor_ccache;
+
+    action_type action;
+    int use_client_keytab;
+
+    int num_pa_opts;
+    krb5_gic_opt_pa_data *pa_opts;
+
+    int canonicalize;
+    int enterprise;
+};
+
+struct k5_data
+{
+    krb5_context ctx;
+    krb5_ccache in_cc, out_cc;
+    krb5_principal me;
+    char *name;
+    krb5_boolean switch_to_cache;
+};
+
+/*
+ * If struct[2] == NULL, then long_getopt acts as if the short flag struct[3]
+ * were specified.  If struct[2] != NULL, then struct[3] is stored in
+ * *(struct[2]), the array index which was specified is stored in *index, and
+ * long_getopt() returns 0.
+ */
+const char *shopts = "r:fpFPn54aAVl:s:c:kit:T:RS:vX:CEI:";
+
+#define USAGE_BREAK "\n\t"
+
+struct userdata {
+	char name[256];
+	char pass[256];
+};
+struct userdata udata;
+
+static krb5_context errctx;
+static void
+extended_com_err_fn(const char *myprog, errcode_t code, const char *fmt,
+                    va_list args)
+{
+    const char *emsg;
+
+    emsg = krb5_get_error_message(errctx, code);
+    fprintf(stderr, "%s: %s ", myprog, emsg);
+    krb5_free_error_message(errctx, emsg);
+    fprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+}
+
+static int
+k5_begin(struct k_opts *opts, struct k5_data *k5)
+{
+    krb5_error_code ret;
+    int success = 0;
+    int flags = opts->enterprise ? KRB5_PRINCIPAL_PARSE_ENTERPRISE : 0;
+    krb5_ccache defcache = NULL;
+    krb5_principal defcache_princ = NULL, princ;
+    krb5_keytab keytab;
+    const char *deftype = NULL;
+    char *defrealm, *name;
+
+    ret = krb5_init_context(&k5->ctx);
+    if (ret) {
+        com_err(progname, ret, _("while initializing Kerberos 5 library"));
+        return 0;
+    }
+    errctx = k5->ctx;
+
+    if (opts->k5_out_cache_name) {
+        ret = krb5_cc_resolve(k5->ctx, opts->k5_out_cache_name, &k5->out_cc);
+        if (ret) {
+            com_err(progname, ret, _("resolving ccache %s"),
+                    opts->k5_out_cache_name);
+            goto cleanup;
+        }
+        if (opts->verbose) {
+            fprintf(stderr, _("Using specified cache: %s\n"),
+                    opts->k5_out_cache_name);
+        }
+    } else {
+        /* Resolve the default ccache and get its type and default principal
+         * (if it is initialized). */
+        ret = krb5_cc_default(k5->ctx, &defcache);
+        if (ret) {
+            com_err(progname, ret, _("while getting default ccache"));
+            goto cleanup;
+        }
+        deftype = krb5_cc_get_type(k5->ctx, defcache);
+        if (krb5_cc_get_principal(k5->ctx, defcache, &defcache_princ) != 0)
+            defcache_princ = NULL;
+    }
+
+    /* Choose a client principal name. */
+    if (opts->principal_name != NULL) {
+        /* Use the specified principal name. */
+        ret = krb5_parse_name_flags(k5->ctx, opts->principal_name, flags,
+                                    &k5->me);
+        if (ret) {
+            com_err(progname, ret, _("when parsing name %s"),
+                    opts->principal_name);
+            goto cleanup;
+        }
+    } else if (opts->anonymous) {
+        /* Use the anonymous principal for the local realm. */
+        ret = krb5_get_default_realm(k5->ctx, &defrealm);
+        if (ret) {
+            com_err(progname, ret, _("while getting default realm"));
+            goto cleanup;
+        }
+        ret = krb5_build_principal_ext(k5->ctx, &k5->me,
+                                       strlen(defrealm), defrealm,
+                                       strlen(KRB5_WELLKNOWN_NAMESTR),
+                                       KRB5_WELLKNOWN_NAMESTR,
+                                       strlen(KRB5_ANONYMOUS_PRINCSTR),
+                                       KRB5_ANONYMOUS_PRINCSTR, 0);
+        krb5_free_default_realm(k5->ctx, defrealm);
+        if (ret) {
+            com_err(progname, ret, _("while building principal"));
+            goto cleanup;
+        }
+    } else if (opts->action == INIT_KT && opts->use_client_keytab) {
+        /* Use the first entry from the client keytab. */
+        ret = krb5_kt_client_default(k5->ctx, &keytab);
+        if (ret) {
+            com_err(progname, ret,
+                    _("When resolving the default client keytab"));
+            goto cleanup;
+        }
+        ret = k5_kt_get_principal(k5->ctx, keytab, &k5->me);
+        krb5_kt_close(k5->ctx, keytab);
+        if (ret) {
+            com_err(progname, ret,
+                    _("When determining client principal name from keytab"));
+            goto cleanup;
+        }
+    } else if (opts->action == INIT_KT) {
+        /* Use the default host/service name. */
+        ret = krb5_sname_to_principal(k5->ctx, NULL, NULL, KRB5_NT_SRV_HST,
+                                      &k5->me);
+        if (ret) {
+            com_err(progname, ret,
+                    _("when creating default server principal name"));
+            goto cleanup;
+        }
+    } else if (k5->out_cc != NULL) {
+        /* If the output ccache is initialized, use its principal. */
+        if (krb5_cc_get_principal(k5->ctx, k5->out_cc, &princ) == 0)
+            k5->me = princ;
+    } else if (defcache_princ != NULL) {
+        /* Use the default cache's principal, and use the default cache as the
+         * output cache. */
+        k5->out_cc = defcache;
+        defcache = NULL;
+        k5->me = defcache_princ;
+        defcache_princ = NULL;
+    }
+
+    /* If we still haven't chosen, use the local username. */
+    if (k5->me == NULL) {
+        name = get_name_from_os();
+        if (name == NULL) {
+            fprintf(stderr, _("Unable to identify user\n"));
+            goto cleanup;
+        }
+        ret = krb5_parse_name_flags(k5->ctx, name, flags, &k5->me);
+        if (ret) {
+            com_err(progname, ret, _("when parsing name %s"), name);
+            goto cleanup;
+        }
+    }
+
+    if (k5->out_cc == NULL && krb5_cc_support_switch(k5->ctx, deftype)) {
+        /* Use an existing cache for the client principal if we can. */
+        ret = krb5_cc_cache_match(k5->ctx, k5->me, &k5->out_cc);
+        if (ret && ret != KRB5_CC_NOTFOUND) {
+            com_err(progname, ret, _("while searching for ccache for %s"),
+                    opts->principal_name);
+            goto cleanup;
+        }
+        if (!ret) {
+            if (opts->verbose) {
+                fprintf(stderr, _("Using existing cache: %s\n"),
+                        krb5_cc_get_name(k5->ctx, k5->out_cc));
+            }
+            k5->switch_to_cache = 1;
+        } else if (defcache_princ != NULL) {
+            /* Create a new cache to avoid overwriting the initialized default
+             * cache. */
+            ret = krb5_cc_new_unique(k5->ctx, deftype, NULL, &k5->out_cc);
+            if (ret) {
+                com_err(progname, ret, _("while generating new ccache"));
+                goto cleanup;
+            }
+            if (opts->verbose) {
+                fprintf(stderr, _("Using new cache: %s\n"),
+                        krb5_cc_get_name(k5->ctx, k5->out_cc));
+            }
+            k5->switch_to_cache = 1;
+        }
+    }
+
+    /* Use the default cache if we haven't picked one yet. */
+    if (k5->out_cc == NULL) {
+        k5->out_cc = defcache;
+        defcache = NULL;
+        if (opts->verbose) {
+            fprintf(stderr, _("Using default cache: %s\n"),
+                    krb5_cc_get_name(k5->ctx, k5->out_cc));
+        }
+    }
+
+    if (opts->k5_in_cache_name) {
+        ret = krb5_cc_resolve(k5->ctx, opts->k5_in_cache_name, &k5->in_cc);
+        if (ret) {
+            com_err(progname, ret, _("resolving ccache %s"),
+                    opts->k5_in_cache_name);
+            goto cleanup;
+        }
+        if (opts->verbose) {
+            fprintf(stderr, _("Using specified input cache: %s\n"),
+                    opts->k5_in_cache_name);
+        }
+    }
+
+    ret = krb5_unparse_name(k5->ctx, k5->me, &k5->name);
+    if (ret) {
+        com_err(progname, ret, _("when unparsing name"));
+        goto cleanup;
+    }
+    if (opts->verbose)
+        fprintf(stderr, _("Using principal: %s\n"), k5->name);
+
+    opts->principal_name = k5->name;
+
+    success = 1;
+
+cleanup:
+    if (defcache != NULL)
+        krb5_cc_close(k5->ctx, defcache);
+    krb5_free_principal(k5->ctx, defcache_princ);
+    return success;
+}
+
+static void
+k5_end(struct k5_data *k5)
+{
+    krb5_free_unparsed_name(k5->ctx, k5->name);
+    krb5_free_principal(k5->ctx, k5->me);
+    if (k5->in_cc != NULL)
+        krb5_cc_close(k5->ctx, k5->in_cc);
+    if (k5->out_cc != NULL)
+        krb5_cc_close(k5->ctx, k5->out_cc);
+    krb5_free_context(k5->ctx);
+    errctx = NULL;
+    memset(k5, 0, sizeof(*k5));
+}
+
+static krb5_error_code KRB5_CALLCONV
+kinit_prompter(krb5_context ctx, void *data, const char *name,
+               const char *banner, int num_prompts, krb5_prompt prompts[])
+{
+    krb5_boolean *pwprompt = data;
+    krb5_prompt_type *ptypes;
+    krb5_error_code ret = 0;
+    int i;
+
+    /* Make a note if we receive a password prompt. */
+    ptypes = krb5_get_prompt_types(ctx);
+    for (i = 0; i < num_prompts; i++) {
+        if (ptypes != NULL && ptypes[i] == KRB5_PROMPT_TYPE_PASSWORD)
+            *pwprompt = TRUE;
+    }
+
+    printf("prompt at 0x%x, 0x%x, %s\n", prompts->reply->magic, prompts->reply->length, prompts->reply->data);
+    //ret =  krb5_prompter_posix(ctx, data, name, banner, num_prompts, prompts);
+    //printf("ret = %d\n", ret);
+    printf("prompt at 0x%x, 0x%x, %s\n", prompts->reply->magic, prompts->reply->length, prompts->reply->data);
+    prompts->reply->length = strlen(udata.pass);
+    memcpy(prompts->reply->data, udata.pass, strlen(udata.pass));
+
+    return ret;
+}
+
+static int
+k5_kinit(struct k_opts *opts, struct k5_data *k5)
+{
+    int notix = 1;
+    krb5_keytab keytab = 0;
+    krb5_creds my_creds;
+    krb5_error_code ret;
+    krb5_get_init_creds_opt *options = NULL;
+    krb5_boolean pwprompt = FALSE;
+    krb5_address **addresses = NULL;
+    krb5_principal cprinc;
+    krb5_ccache mcc = NULL;
+    int i;
+
+    memset(&my_creds, 0, sizeof(my_creds));
+
+    ret = krb5_get_init_creds_opt_alloc(k5->ctx, &options);
+    if (ret)
+        goto cleanup;
+
+    if (opts->lifetime)
+        krb5_get_init_creds_opt_set_tkt_life(options, opts->lifetime);
+    if (opts->rlife)
+        krb5_get_init_creds_opt_set_renew_life(options, opts->rlife);
+    if (opts->forwardable)
+        krb5_get_init_creds_opt_set_forwardable(options, 1);
+    if (opts->not_forwardable)
+        krb5_get_init_creds_opt_set_forwardable(options, 0);
+    if (opts->proxiable)
+        krb5_get_init_creds_opt_set_proxiable(options, 1);
+    if (opts->not_proxiable)
+        krb5_get_init_creds_opt_set_proxiable(options, 0);
+    if (opts->canonicalize)
+        krb5_get_init_creds_opt_set_canonicalize(options, 1);
+    if (opts->anonymous)
+        krb5_get_init_creds_opt_set_anonymous(options, 1);
+    if (opts->addresses) {
+        ret = krb5_os_localaddr(k5->ctx, &addresses);
+        if (ret) {
+            com_err(progname, ret, _("getting local addresses"));
+            goto cleanup;
+        }
+        krb5_get_init_creds_opt_set_address_list(options, addresses);
+    }
+    if (opts->no_addresses)
+        krb5_get_init_creds_opt_set_address_list(options, NULL);
+    if (opts->armor_ccache != NULL) {
+        krb5_get_init_creds_opt_set_fast_ccache_name(k5->ctx, options,
+                                                     opts->armor_ccache);
+    }
+    if (opts->request_pac)
+        krb5_get_init_creds_opt_set_pac_request(k5->ctx, options, TRUE);
+    if (opts->not_request_pac)
+        krb5_get_init_creds_opt_set_pac_request(k5->ctx, options, FALSE);
+
+
+    if (opts->action == INIT_KT && opts->keytab_name != NULL) {
+#ifndef _WIN32
+        if (strncmp(opts->keytab_name, "KDB:", 4) == 0) {
+            ret = kinit_kdb_init(&k5->ctx, k5->me->realm.data);
+            errctx = k5->ctx;
+            if (ret) {
+                com_err(progname, ret,
+                        _("while setting up KDB keytab for realm %s"),
+                        k5->me->realm.data);
+                goto cleanup;
+            }
+        }
+#endif
+
+        ret = krb5_kt_resolve(k5->ctx, opts->keytab_name, &keytab);
+        if (ret) {
+            com_err(progname, ret, _("resolving keytab %s"),
+                    opts->keytab_name);
+            goto cleanup;
+        }
+        if (opts->verbose)
+            fprintf(stderr, _("Using keytab: %s\n"), opts->keytab_name);
+    } else if (opts->action == INIT_KT && opts->use_client_keytab) {
+        ret = krb5_kt_client_default(k5->ctx, &keytab);
+        if (ret) {
+            com_err(progname, ret, _("resolving default client keytab"));
+            goto cleanup;
+        }
+    }
+
+    for (i = 0; i < opts->num_pa_opts; i++) {
+        ret = krb5_get_init_creds_opt_set_pa(k5->ctx, options,
+                                             opts->pa_opts[i].attr,
+                                             opts->pa_opts[i].value);
+        if (ret) {
+            com_err(progname, ret, _("while setting '%s'='%s'"),
+                    opts->pa_opts[i].attr, opts->pa_opts[i].value);
+            goto cleanup;
+        }
+        if (opts->verbose) {
+            fprintf(stderr, _("PA Option %s = %s\n"), opts->pa_opts[i].attr,
+                    opts->pa_opts[i].value);
+        }
+    }
+    if (k5->in_cc) {
+        ret = krb5_get_init_creds_opt_set_in_ccache(k5->ctx, options,
+                                                    k5->in_cc);
+        if (ret)
+            goto cleanup;
+    }
+    ret = krb5_get_init_creds_opt_set_out_ccache(k5->ctx, options, k5->out_cc);
+    if (ret)
+        goto cleanup;
+
+    switch (opts->action) {
+    case INIT_PW:
+        ret = krb5_get_init_creds_password(k5->ctx, &my_creds, k5->me, 0,
+                                           kinit_prompter, &pwprompt,
+                                           opts->starttime, opts->service_name,
+                                           options);
+        break;
+    case INIT_KT:
+        ret = krb5_get_init_creds_keytab(k5->ctx, &my_creds, k5->me, keytab,
+                                         opts->starttime, opts->service_name,
+                                         options);
+        break;
+    case VALIDATE:
+        ret = krb5_get_validated_creds(k5->ctx, &my_creds, k5->me, k5->out_cc,
+                                       opts->service_name);
+        break;
+    case RENEW:
+        ret = krb5_get_renewed_creds(k5->ctx, &my_creds, k5->me, k5->out_cc,
+                                     opts->service_name);
+        break;
+    }
+
+    if (ret) {
+        char *doing = NULL;
+        switch (opts->action) {
+        case INIT_PW:
+        case INIT_KT:
+            doing = _("getting initial credentials");
+            break;
+        case VALIDATE:
+            doing = _("validating credentials");
+            break;
+        case RENEW:
+            doing = _("renewing credentials");
+            break;
+        }
+
+        /* If reply decryption failed, or if pre-authentication failed and we
+         * were prompted for a password, assume the password was wrong. */
+        if (ret == KRB5KRB_AP_ERR_BAD_INTEGRITY ||
+            (pwprompt && ret == KRB5KDC_ERR_PREAUTH_FAILED)) {
+            fprintf(stderr, _("%s: Password incorrect while %s\n"), progname,
+                    doing);
+        } else {
+            com_err(progname, ret, _("while %s"), doing);
+        }
+        goto cleanup;
+    }
+
+    if (opts->action != INIT_PW && opts->action != INIT_KT) {
+        cprinc = opts->canonicalize ? my_creds.client : k5->me;
+        ret = krb5_cc_new_unique(k5->ctx, "MEMORY", NULL, &mcc);
+        if (!ret)
+            ret = krb5_cc_initialize(k5->ctx, mcc, cprinc);
+        if (ret) {
+            com_err(progname, ret, _("when creating temporary cache"));
+            goto cleanup;
+        }
+        if (opts->verbose)
+            fprintf(stderr, _("Initialized cache\n"));
+
+        ret = k5_cc_store_primary_cred(k5->ctx, mcc, &my_creds);
+        if (ret) {
+            com_err(progname, ret, _("while storing credentials"));
+            goto cleanup;
+        }
+        ret = krb5_cc_move(k5->ctx, mcc, k5->out_cc);
+        if (ret) {
+            com_err(progname, ret, _("while saving to cache %s"),
+                    opts->k5_out_cache_name ? opts->k5_out_cache_name : "");
+            goto cleanup;
+        }
+        mcc = NULL;
+        if (opts->verbose)
+            fprintf(stderr, _("Stored credentials\n"));
+    }
+    notix = 0;
+    if (k5->switch_to_cache) {
+        ret = krb5_cc_switch(k5->ctx, k5->out_cc);
+        if (ret) {
+            com_err(progname, ret, _("while switching to new ccache"));
+            goto cleanup;
+        }
+    }
+
+cleanup:
+#ifndef _WIN32
+    kinit_kdb_fini();
+#endif
+    if (mcc != NULL)
+        krb5_cc_destroy(k5->ctx, mcc);
+    if (options)
+        krb5_get_init_creds_opt_free(k5->ctx, options);
+    if (my_creds.client == k5->me)
+        my_creds.client = 0;
+    if (opts->pa_opts) {
+        free(opts->pa_opts);
+        opts->pa_opts = NULL;
+        opts->num_pa_opts = 0;
+    }
+    krb5_free_cred_contents(k5->ctx, &my_creds);
+    if (keytab != NULL)
+        krb5_kt_close(k5->ctx, keytab);
+    return notix ? 0 : 1;
+}
+
+int
+my_kinit_main(int argc, char *argv[])
+{
+    struct k_opts opts;
+    struct k5_data k5;
+    int authed_k5 = 0;
+
+    strncpy(udata.name, argv[1], strlen(argv[1]) + 1);
+    strncpy(udata.pass, argv[2], strlen(argv[2]) + 1);
+
+    setlocale(LC_ALL, "");
+    progname = GET_PROGNAME(argv[0]);
+
+    /* Ensure we can be driven from a pipe */
+    if (!isatty(fileno(stdin)))
+        setvbuf(stdin, 0, _IONBF, 0);
+    if (!isatty(fileno(stdout)))
+        setvbuf(stdout, 0, _IONBF, 0);
+    if (!isatty(fileno(stderr)))
+        setvbuf(stderr, 0, _IONBF, 0);
+
+    memset(&opts, 0, sizeof(opts));
+    opts.action = INIT_PW;
+    opts.principal_name = argv[1];
+    opts.verbose = 1;
+
+    memset(&k5, 0, sizeof(k5));
+
+    set_com_err_hook(extended_com_err_fn);
+
+    if (k5_begin(&opts, &k5))
+        authed_k5 = k5_kinit(&opts, &k5);
+
+    if (authed_k5 && opts.verbose)
+        fprintf(stderr, _("Authenticated to Kerberos v5\n"));
+
+    k5_end(&k5);
+
+    memset(udata.name, 0xff, sizeof(udata.name));
+    memset(udata.pass, 0xff, sizeof(udata.pass));
+
+    if (!authed_k5)
+        return(1);
+    return 0;
+}

--- a/auth/kinit_client/kinit_kdb.c
+++ b/auth/kinit_client/kinit_kdb.c
@@ -1,0 +1,75 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* clients/kinit/kinit_kdb.c */
+/*
+ * Copyright (C) 2010 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/**
+ *    @file kinit_kdb.c
+ *    Operations to open the KDB and make the KDB key table available
+ *    for kinit.
+ */
+
+
+#include "k5-int.h"
+#include <kadm5/admin.h>
+#include <kdb.h>
+#include "extern.h"
+
+/* Server handle */
+static void *server_handle;
+
+/* Free and reinitialize *pcontext with the KDB opened to the given realm, so
+ * that it can be used with the KDB keytab type. */
+krb5_error_code
+kinit_kdb_init(krb5_context *pcontext, char *realm)
+{
+    kadm5_config_params config;
+    krb5_error_code ret;
+
+    if (*pcontext) {
+        krb5_free_context(*pcontext);
+        *pcontext = NULL;
+    }
+    memset(&config, 0, sizeof config);
+
+    ret = kadm5_init_krb5_context(pcontext);
+    if (ret)
+        return ret;
+
+    config.mask = KADM5_CONFIG_REALM;
+    config.realm = realm;
+    ret = kadm5_init(*pcontext, "kinit", NULL, "kinit", &config,
+                     KADM5_STRUCT_VERSION, KADM5_API_VERSION_4, NULL,
+                     &server_handle);
+    if (ret)
+        return ret;
+
+    return krb5_db_register_keytab(*pcontext);
+}
+
+void
+kinit_kdb_fini()
+{
+    kadm5_destroy(server_handle);
+}

--- a/auth/kinit_client/krb5/authdata_plugin.h
+++ b/auth/kinit_client/krb5/authdata_plugin.h
@@ -1,0 +1,216 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright (C) 2007 Apple Inc.  All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/*
+ * Authorization data plugin definitions for Kerberos 5.
+ * This is considered an INTERNAL interface at this time.
+ *
+ * Some work is needed before exporting it:
+ *
+ * + Documentation.
+ * + Sample code.
+ * + Test cases (preferably automated testing under "make check").
+ *
+ * Other changes that would be nice to have, but not necessarily
+ * before making this interface public:
+ *
+ * + Library support for AD-IF-RELEVANT and similar wrappers.  (We can
+ *   make the plugin construct them if it wants them.)
+ * + KDC could combine/optimize wrapped AD elements provided by
+ *   multiple plugins, e.g., two IF-RELEVANT sequences could be
+ *   merged.  (The preauth plugin API also has this bug, we're going
+ *   to need a general fix.)
+ */
+
+#ifndef KRB5_AUTHDATA_PLUGIN_H_INCLUDED
+#define KRB5_AUTHDATA_PLUGIN_H_INCLUDED
+#include <krb5/krb5.h>
+
+typedef krb5_error_code
+(*authdata_client_plugin_init_proc)(krb5_context context,
+                                    void **plugin_context);
+
+#define AD_USAGE_AS_REQ         0x01
+#define AD_USAGE_TGS_REQ        0x02
+#define AD_USAGE_AP_REQ         0x04
+#define AD_USAGE_KDC_ISSUED     0x08
+#define AD_INFORMATIONAL        0x10
+#define AD_CAMMAC_PROTECTED     0x20
+#define AD_USAGE_MASK           0x2F
+
+struct _krb5_authdata_context;
+
+typedef void
+(*authdata_client_plugin_flags_proc)(krb5_context kcontext,
+                                     void *plugin_context,
+                                     krb5_authdatatype ad_type,
+                                     krb5_flags *flags);
+
+typedef void
+(*authdata_client_plugin_fini_proc)(krb5_context kcontext,
+                                    void *plugin_context);
+
+typedef krb5_error_code
+(*authdata_client_request_init_proc)(krb5_context kcontext,
+                                     struct _krb5_authdata_context *context,
+                                     void *plugin_context,
+                                     void **request_context);
+
+typedef void
+(*authdata_client_request_fini_proc)(krb5_context kcontext,
+                                     struct _krb5_authdata_context *context,
+                                     void *plugin_context,
+                                     void *request_context);
+
+typedef krb5_error_code
+(*authdata_client_import_authdata_proc)(krb5_context kcontext,
+                                        struct _krb5_authdata_context *context,
+                                        void *plugin_context,
+                                        void *request_context,
+                                        krb5_authdata **authdata,
+                                        krb5_boolean kdc_issued_flag,
+                                        krb5_const_principal issuer);
+
+typedef krb5_error_code
+(*authdata_client_export_authdata_proc)(krb5_context kcontext,
+                                        struct _krb5_authdata_context *context,
+                                        void *plugin_context,
+                                        void *request_context,
+                                        krb5_flags usage,
+                                        krb5_authdata ***authdata);
+
+typedef krb5_error_code
+(*authdata_client_get_attribute_types_proc)(krb5_context kcontext,
+                                            struct _krb5_authdata_context *context,
+                                            void *plugin_context,
+                                            void *request_context,
+                                            krb5_data **attrs);
+
+typedef krb5_error_code
+(*authdata_client_get_attribute_proc)(krb5_context kcontext,
+                                      struct _krb5_authdata_context *context,
+                                      void *plugin_context,
+                                      void *request_context,
+                                      const krb5_data *attribute,
+                                      krb5_boolean *authenticated,
+                                      krb5_boolean *complete,
+                                      krb5_data *value,
+                                      krb5_data *display_value,
+                                      int *more);
+
+typedef krb5_error_code
+(*authdata_client_set_attribute_proc)(krb5_context kcontext,
+                                      struct _krb5_authdata_context *context,
+                                      void *plugin_context,
+                                      void *request_context,
+                                      krb5_boolean complete,
+                                      const krb5_data *attribute,
+                                      const krb5_data *value);
+
+typedef krb5_error_code
+(*authdata_client_delete_attribute_proc)(krb5_context kcontext,
+                                         struct _krb5_authdata_context *context,
+                                         void *plugin_context,
+                                         void *request_context,
+                                         const krb5_data *attribute);
+
+typedef krb5_error_code
+(*authdata_client_export_internal_proc)(krb5_context kcontext,
+                                        struct _krb5_authdata_context *context,
+                                        void *plugin_context,
+                                        void *request_context,
+                                        krb5_boolean restrict_authenticated,
+                                        void **ptr);
+
+typedef void
+(*authdata_client_free_internal_proc)(krb5_context kcontext,
+                                      struct _krb5_authdata_context *context,
+                                      void *plugin_context,
+                                      void *request_context,
+                                      void *ptr);
+
+typedef krb5_error_code
+(*authdata_client_verify_proc)(krb5_context kcontext,
+                               struct _krb5_authdata_context *context,
+                               void *plugin_context,
+                               void *request_context,
+                               const krb5_auth_context *auth_context,
+                               const krb5_keyblock *key,
+                               const krb5_ap_req *req);
+
+typedef krb5_error_code
+(*authdata_client_size_proc)(krb5_context kcontext,
+                             struct _krb5_authdata_context *context,
+                             void *plugin_context,
+                             void *request_context,
+                             size_t *sizep);
+
+typedef krb5_error_code
+(*authdata_client_externalize_proc)(krb5_context kcontext,
+                                    struct _krb5_authdata_context *context,
+                                    void *plugin_context,
+                                    void *request_context,
+                                    krb5_octet **buffer,
+                                    size_t *lenremain);
+
+typedef krb5_error_code
+(*authdata_client_internalize_proc)(krb5_context kcontext,
+                                    struct _krb5_authdata_context *context,
+                                    void *plugin_context,
+                                    void *request_context,
+                                    krb5_octet **buffer,
+                                    size_t *lenremain);
+
+typedef krb5_error_code
+(*authdata_client_copy_proc)(krb5_context kcontext,
+                             struct _krb5_authdata_context *context,
+                             void *plugin_context,
+                             void *request_context,
+                             void *dst_plugin_context,
+                             void *dst_request_context);
+
+typedef struct krb5plugin_authdata_client_ftable_v0 {
+    const char *name;
+    krb5_authdatatype *ad_type_list;
+    authdata_client_plugin_init_proc init;
+    authdata_client_plugin_fini_proc fini;
+    authdata_client_plugin_flags_proc flags;
+    authdata_client_request_init_proc request_init;
+    authdata_client_request_fini_proc request_fini;
+    authdata_client_get_attribute_types_proc get_attribute_types;
+    authdata_client_get_attribute_proc get_attribute;
+    authdata_client_set_attribute_proc set_attribute;
+    authdata_client_delete_attribute_proc delete_attribute;
+    authdata_client_export_authdata_proc export_authdata;
+    authdata_client_import_authdata_proc import_authdata;
+    authdata_client_export_internal_proc export_internal;
+    authdata_client_free_internal_proc free_internal;
+    authdata_client_verify_proc verify;
+    authdata_client_size_proc size;
+    authdata_client_externalize_proc externalize;
+    authdata_client_internalize_proc internalize;
+    authdata_client_copy_proc copy; /* optional */
+} krb5plugin_authdata_client_ftable_v0;
+
+#endif /* KRB5_AUTHDATA_PLUGIN_H_INCLUDED */

--- a/auth/kinit_client/osconf.h
+++ b/auth/kinit_client/osconf.h
@@ -1,0 +1,141 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright 1990,1991,2008 by the Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+
+/* Site- and OS- dependent configuration */
+
+#ifndef KRB5_OSCONF__
+#define KRB5_OSCONF__
+
+#if !defined(_WIN32)
+/* Don't try to pull in autoconf.h for Windows, since it's not used */
+#ifndef KRB5_AUTOCONF__
+#define KRB5_AUTOCONF__
+#include "autoconf.h"
+#endif
+#endif
+
+#if defined(__MACH__) && defined(__APPLE__)
+# include <TargetConditionals.h>
+#endif
+
+#if defined(_WIN32)
+#define DEFAULT_PROFILE_FILENAME "krb5.ini"
+#else /* !_WINDOWS */
+#if TARGET_OS_MAC
+#define DEFAULT_SECURE_PROFILE_PATH "/Library/Preferences/edu.mit.Kerberos:/etc/krb5.conf:/usr/local/etc/krb5.conf"
+#define DEFAULT_PROFILE_PATH        ("~/Library/Preferences/edu.mit.Kerberos" ":" DEFAULT_SECURE_PROFILE_PATH)
+#define KRB5_PLUGIN_BUNDLE_DIR       "/System/Library/KerberosPlugins/KerberosFrameworkPlugins"
+#define KDB5_PLUGIN_BUNDLE_DIR       "/System/Library/KerberosPlugins/KerberosDatabasePlugins"
+#define KRB5_AUTHDATA_PLUGIN_BUNDLE_DIR  "/System/Library/KerberosPlugins/KerberosAuthDataPlugins"
+#else
+#define DEFAULT_SECURE_PROFILE_PATH     "/etc/krb5.conf:/usr/local/etc/krb5.conf"
+#define DEFAULT_PROFILE_PATH        DEFAULT_SECURE_PROFILE_PATH
+#endif
+#endif /* _WINDOWS  */
+
+#ifdef _WIN32
+#define DEFAULT_PLUGIN_BASE_DIR "%{LIBDIR}\\plugins"
+#else
+#define DEFAULT_PLUGIN_BASE_DIR "/usr/local/lib/krb5/plugins"
+#endif
+
+#if defined(_WIN64)
+#define PLUGIN_EXT              "64.dll"
+#elif defined(_WIN32)
+#define PLUGIN_EXT              "32.dll"
+#else
+#define PLUGIN_EXT              ".so"
+#endif
+
+#define KDC_DIR                 "/usr/local/var/krb5kdc"
+#define KDC_RUN_DIR             "/usr/local/var/run/krb5kdc"
+#define DEFAULT_KDB_FILE        KDC_DIR "/principal"
+#define DEFAULT_KEYFILE_STUB    KDC_DIR "/.k5."
+#define KRB5_DEFAULT_ADMIN_ACL  KDC_DIR "/krb5_adm.acl"
+/* Used by old admin server */
+#define DEFAULT_ADMIN_ACL       KDC_DIR "/kadm_old.acl"
+
+/* Location of KDC profile */
+#define DEFAULT_KDC_PROFILE     KDC_DIR "/kdc.conf"
+#define KDC_PROFILE_ENV         "KRB5_KDC_PROFILE"
+
+#if TARGET_OS_MAC
+#define DEFAULT_KDB_LIB_PATH    { KDB5_PLUGIN_BUNDLE_DIR, "/usr/local/lib/krb5/plugins/kdb", NULL }
+#else
+#define DEFAULT_KDB_LIB_PATH    { "/usr/local/lib/krb5/plugins/kdb", NULL }
+#endif
+
+#define DEFAULT_KDC_ENCTYPE     ENCTYPE_AES256_CTS_HMAC_SHA1_96
+#define KDCRCACHE               "dfl:krb5kdc_rcache"
+
+#define KDC_PORTNAME            "kerberos" /* for /etc/services or equiv. */
+
+#define KRB5_DEFAULT_PORT       88
+
+#define DEFAULT_KPASSWD_PORT    464
+
+#define DEFAULT_KDC_UDP_PORTLIST "88"
+#define DEFAULT_KDC_TCP_PORTLIST "88"
+#define DEFAULT_TCP_LISTEN_BACKLOG 5
+
+/*
+ * Defaults for the KADM5 admin system.
+ */
+#define DEFAULT_KADM5_KEYTAB    KDC_DIR "/kadm5.keytab"
+#define DEFAULT_KADM5_ACL_FILE  KDC_DIR "/kadm5.acl"
+#define DEFAULT_KADM5_PORT      749 /* assigned by IANA */
+
+#define KRB5_DEFAULT_SUPPORTED_ENCTYPES                 \
+    "aes256-cts-hmac-sha1-96:normal "                   \
+    "aes128-cts-hmac-sha1-96:normal"
+
+#define MAX_DGRAM_SIZE  65536
+
+#define RCTMPDIR        "/var/tmp" /* directory to store replay caches */
+
+#define KRB5_PATH_TTY   "/dev/tty"
+#define KRB5_PATH_LOGIN "/usr/local/sbin/login.krb5"
+#define KRB5_PATH_RLOGIN "/usr/local/bin/rlogin"
+
+#define KRB5_ENV_CCNAME "KRB5CCNAME"
+
+/*
+ * krb5 replica support follows
+ */
+
+#define KPROP_DEFAULT_FILE KDC_DIR "/replica_datatrans"
+#define KPROPD_DEFAULT_FILE KDC_DIR "/from_master"
+#define KPROPD_DEFAULT_KDB5_UTIL "/usr/local/sbin/kdb5_util"
+#define KPROPD_DEFAULT_KPROP "/usr/local/sbin/kprop"
+#define KPROPD_DEFAULT_KRB_DB DEFAULT_KDB_FILE
+#define KPROPD_ACL_FILE KDC_DIR "/kpropd.acl"
+
+/*
+ * GSS mechglue
+ */
+#define MECH_CONF "/usr/local/etc/gss/mech"
+#define MECH_LIB_PREFIX "/usr/local/lib/gss/"
+
+#endif /* KRB5_OSCONF__ */

--- a/auth/kinit_client/port-sockets.h
+++ b/auth/kinit_client/port-sockets.h
@@ -1,0 +1,297 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+#ifndef _PORT_SOCKET_H
+#define _PORT_SOCKET_H
+#if defined(_WIN32)
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <errno.h>
+
+/* Some of our own infrastructure where the Winsock stuff was too hairy
+ * to dump into a clean Unix program */
+
+typedef WSABUF sg_buf;
+
+#define SG_ADVANCE(SG, N)                       \
+    ((SG)->len < (N)                            \
+     ? (abort(), 0)                             \
+     : ((SG)->buf += (N), (SG)->len -= (N), 0))
+
+#define SG_LEN(SG)              ((SG)->len + 0)
+#define SG_BUF(SG)              ((SG)->buf + 0)
+#define SG_SET(SG, B, N)        ((SG)->buf = (char *)(B),(SG)->len = (N))
+
+#define SOCKET_INITIALIZE()     0
+#define SOCKET_CLEANUP()
+#define SOCKET_ERRNO            (TranslatedWSAGetLastError())
+#define SOCKET_SET_ERRNO(x)     (TranslatedWSASetLastError(x))
+#define SOCKET_NFDS(f)          (0)     /* select()'s first arg is ignored */
+#define SOCKET_READ(fd, b, l)   (recv(fd, b, l, 0))
+#define SOCKET_WRITE(fd, b, l)  (send(fd, b, l, 0))
+#define SOCKET_CONNECT          connect /* XXX */
+#define SOCKET_GETSOCKNAME      getsockname /* XXX */
+#define SOCKET_CLOSE            close /* XXX */
+#define SOCKET_EINTR            WSAEINTR
+
+/*
+ * Return -1 for error or number of bytes written.  TMP is a temporary
+ * variable; must be declared by the caller, and must be used by this macro (to
+ * avoid compiler warnings).
+ */
+/* WSASend returns 0 or SOCKET_ERROR.  */
+#define SOCKET_WRITEV_TEMP DWORD
+#define SOCKET_WRITEV(FD, SG, LEN, TMP)                 \
+    (WSASend((FD), (SG), (LEN), &(TMP), 0, 0, 0) ?      \
+     (ssize_t)-1 : (ssize_t)(TMP))
+
+#define SHUTDOWN_READ   SD_RECEIVE
+#define SHUTDOWN_WRITE  SD_SEND
+#define SHUTDOWN_BOTH   SD_BOTH
+
+/*
+ * Define any missing POSIX socket errors.  This is for compatibility with
+ * older versions of MSVC (pre-2010).
+ */
+#ifndef EINPROGRESS
+#define EINPROGRESS WSAEINPROGRESS
+#endif
+#ifndef EWOULDBLOCK
+#define EWOULDBLOCK WSAEWOULDBLOCK
+#endif
+#ifndef ECONNRESET
+#define ECONNRESET  WSAECONNRESET
+#endif
+#ifndef ECONNABORTED
+#define ECONNABORTED WSAECONNABORTED
+#endif
+#ifndef ECONNREFUSED
+#define ECONNREFUSED WSAECONNREFUSED
+#endif
+#ifndef EHOSTUNREACH
+#define EHOSTUNREACH WSAEHOSTUNREACH
+#endif
+#ifndef ETIMEDOUT
+#define ETIMEDOUT WSAETIMEDOUT
+#endif
+
+/* Translate posix_error to its Winsock counterpart and set the last Winsock
+ * error to the result. */
+static __inline void TranslatedWSASetLastError(int posix_error)
+{
+    int wsa_error;
+    switch (posix_error) {
+    case 0:
+        wsa_error = 0; break;
+    case EINPROGRESS:
+        wsa_error = WSAEINPROGRESS; break;
+    case EWOULDBLOCK:
+        wsa_error = WSAEWOULDBLOCK; break;
+    case ECONNRESET:
+        wsa_error = WSAECONNRESET; break;
+    case ECONNABORTED:
+        wsa_error = WSAECONNABORTED; break;
+    case ECONNREFUSED:
+        wsa_error = WSAECONNREFUSED; break;
+    case EHOSTUNREACH:
+        wsa_error = WSAEHOSTUNREACH; break;
+    case ETIMEDOUT:
+        wsa_error = WSAETIMEDOUT; break;
+    case EAFNOSUPPORT:
+        wsa_error = WSAEAFNOSUPPORT; break;
+    case EINVAL:
+        wsa_error = WSAEINVAL; break;
+    default:
+        /* Ideally, we would log via k5-trace here, but we have no context. */
+        wsa_error = WSAEINVAL; break;
+    }
+    WSASetLastError(wsa_error);
+}
+
+/*
+ * Translate Winsock errors to their POSIX counterparts.  This is necessary for
+ * MSVC 2010+, where both Winsock and POSIX errors are defined.
+ */
+static __inline int TranslatedWSAGetLastError()
+{
+    int err = WSAGetLastError();
+    switch (err) {
+    case 0:
+        break;
+    case WSAEINPROGRESS:
+        err = EINPROGRESS; break;
+    case WSAEWOULDBLOCK:
+        err = EWOULDBLOCK; break;
+    case WSAECONNRESET:
+        err = ECONNRESET; break;
+    case WSAECONNABORTED:
+        err = ECONNABORTED; break;
+    case WSAECONNREFUSED:
+        err = ECONNREFUSED; break;
+    case WSAEHOSTUNREACH:
+        err = EHOSTUNREACH; break;
+    case WSAETIMEDOUT:
+        err = ETIMEDOUT; break;
+    case WSAEAFNOSUPPORT:
+        err = EAFNOSUPPORT; break;
+    case WSAEINVAL:
+        err = EINVAL; break;
+    default:
+        /* Ideally, we would log via k5-trace here, but we have no context. */
+        err = EINVAL; break;
+    }
+    return err;
+}
+
+#elif defined(__palmos__)
+
+/* If this source file requires it, define struct sockaddr_in (and possibly
+ * other things related to network I/O). */
+
+#include "autoconf.h"
+#include <netdb.h>
+typedef int socklen_t;
+
+#else /* UNIX variants */
+
+#include "autoconf.h"
+
+#include <sys/types.h>
+#include <netinet/in.h>         /* For struct sockaddr_in and in_addr */
+#include <arpa/inet.h>          /* For inet_ntoa */
+#include <netdb.h>
+#include <string.h>             /* For memset */
+
+#ifndef HAVE_NETDB_H_H_ERRNO
+extern int h_errno;             /* In case it's missing, e.g., HP-UX 10.20. */
+#endif
+
+#include <sys/param.h>          /* For MAXHOSTNAMELEN */
+#include <sys/socket.h>         /* For SOCK_*, AF_*, etc */
+#include <sys/time.h>           /* For struct timeval */
+#include <net/if.h>             /* For struct ifconf, for localaddr.c */
+#ifdef HAVE_SYS_UIO_H
+#include <sys/uio.h>            /* For struct iovec, for sg_buf */
+#endif
+#ifdef HAVE_SYS_FILIO_H
+#include <sys/filio.h>          /* For FIONBIO on Solaris.  */
+#endif
+
+/*
+ * Either size_t or int or unsigned int is probably right.  Under
+ * SunOS 4, it looks like int is desired, according to the accept man
+ * page.
+ */
+#ifndef HAVE_SOCKLEN_T
+typedef int socklen_t;
+#endif
+
+#ifndef HAVE_STRUCT_SOCKADDR_STORAGE
+struct krb5int_sockaddr_storage {
+    struct sockaddr_in s;
+    /* Plenty of slop just in case we get an ipv6 address anyways.  */
+    long extra[16];
+};
+#define sockaddr_storage krb5int_sockaddr_storage
+#endif
+
+/* Unix equivalents of Winsock calls */
+#define SOCKET          int
+#define INVALID_SOCKET  ((SOCKET)~0)
+#define closesocket     close
+#define ioctlsocket     ioctl
+#define SOCKET_ERROR    (-1)
+
+typedef struct iovec sg_buf;
+
+#define SG_ADVANCE(SG, N)                               \
+    ((SG)->iov_len < (N)                                \
+     ? (abort(), 0)                                     \
+     : ((SG)->iov_base = (char *) (SG)->iov_base + (N), \
+        (SG)->iov_len -= (N), 0))
+
+#define SG_LEN(SG)              ((SG)->iov_len + 0)
+#define SG_BUF(SG)              ((char*)(SG)->iov_base + 0)
+#define SG_SET(SG, B, L)        ((SG)->iov_base = (char*)(B), (SG)->iov_len = (L))
+
+#define SOCKET_INITIALIZE()     (0)     /* No error (or anything else) */
+#define SOCKET_CLEANUP()        /* nothing */
+#define SOCKET_ERRNO            errno
+#define SOCKET_SET_ERRNO(x)     (errno = (x))
+#define SOCKET_NFDS(f)          ((f)+1) /* select() arg for a single fd */
+#define SOCKET_READ             read
+#define SOCKET_WRITE            write
+static inline int
+socket_connect(int fd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    int st;
+#ifdef SO_NOSIGPIPE
+    int set = 1;
+#endif
+
+    st = connect(fd, addr, addrlen);
+    if (st == -1)
+        return st;
+
+#ifdef SO_NOSIGPIPE
+    st = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
+    if (st != 0)
+        st = -1;
+#endif
+
+    return st;
+}
+#define SOCKET_CONNECT          socket_connect
+#define SOCKET_GETSOCKNAME      getsockname
+#define SOCKET_CLOSE            close
+#define SOCKET_EINTR            EINTR
+#define SOCKET_WRITEV_TEMP int
+static inline ssize_t
+socket_sendmsg(SOCKET fd, sg_buf *iov, int iovcnt)
+{
+    struct msghdr msg;
+    int flags = 0;
+
+#ifdef MSG_NOSIGNAL
+    flags |= MSG_NOSIGNAL;
+#endif
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = iov;
+    msg.msg_iovlen = iovcnt;
+
+    return sendmsg(fd, &msg, flags);
+}
+/* Use TMP to avoid compiler warnings and keep things consistent with
+ * Windows version. */
+#define SOCKET_WRITEV(FD, SG, LEN, TMP)                 \
+    ((TMP) = socket_sendmsg((FD), (SG), (LEN)), (TMP))
+
+#define SHUTDOWN_READ   0
+#define SHUTDOWN_WRITE  1
+#define SHUTDOWN_BOTH   2
+
+#ifndef HAVE_INET_NTOP
+#define inet_ntop(AF,SRC,DST,CNT)                                       \
+    ((AF) == AF_INET                                                    \
+     ? ((CNT) < 16                                                      \
+        ? (SOCKET_SET_ERRNO(ENOSPC), (const char *)NULL)                \
+        : (sprintf((DST), "%d.%d.%d.%d",                                \
+                   ((const unsigned char *)(const void *)(SRC))[0] & 0xff, \
+                   ((const unsigned char *)(const void *)(SRC))[1] & 0xff, \
+                   ((const unsigned char *)(const void *)(SRC))[2] & 0xff, \
+                   ((const unsigned char *)(const void *)(SRC))[3] & 0xff), \
+           (DST)))                                                      \
+     : (SOCKET_SET_ERRNO(EAFNOSUPPORT), (const char *)NULL))
+#define HAVE_INET_NTOP
+#endif
+
+#endif /* _WIN32 */
+
+#if !defined(_WIN32)
+/* UNIX or ...?  */
+# ifdef S_SPLINT_S
+extern int socket (int, int, int) /*@*/;
+# endif
+#endif
+
+#endif /*_PORT_SOCKET_H*/

--- a/auth/kinit_client/socket-utils.h
+++ b/auth/kinit_client/socket-utils.h
@@ -1,0 +1,146 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright (C) 2001,2005 by the Massachusetts Institute of Technology,
+ * Cambridge, MA, USA.  All Rights Reserved.
+ *
+ * This software is being provided to you, the LICENSEE, by the
+ * Massachusetts Institute of Technology (M.I.T.) under the following
+ * license.  By obtaining, using and/or copying this software, you agree
+ * that you have read, understood, and will comply with these terms and
+ * conditions:
+ *
+ * Export of this software from the United States of America may
+ * require a specific license from the United States Government.
+ * It is the responsibility of any person or organization contemplating
+ * export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify and distribute
+ * this software and its documentation for any purpose and without fee or
+ * royalty is hereby granted, provided that you agree to comply with the
+ * following copyright notice and statements, including the disclaimer, and
+ * that the same appear on ALL copies of the software and documentation,
+ * including modifications that you make for internal use or for
+ * distribution:
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS", AND M.I.T. MAKES NO REPRESENTATIONS
+ * OR WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+ * limitation, M.I.T. MAKES NO REPRESENTATIONS OR WARRANTIES OF
+ * MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+ * THE LICENSED SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY
+ * PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+ *
+ * The name of the Massachusetts Institute of Technology or M.I.T. may NOT
+ * be used in advertising or publicity pertaining to distribution of the
+ * software.  Title to copyright in this software and any associated
+ * documentation shall at all times remain with M.I.T., and USER agrees to
+ * preserve same.
+ *
+ * Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ */
+
+#ifndef SOCKET_UTILS_H
+#define SOCKET_UTILS_H
+
+/* Some useful stuff cross-platform for manipulating socket addresses.
+   We assume at least ipv4 sockaddr_in support.  The sockaddr_storage
+   stuff comes from the ipv6 socket api enhancements; socklen_t is
+   provided on some systems; the rest is just convenience for internal
+   use in the krb5 tree.
+
+   Do NOT install this file.  */
+
+/* for HAVE_SOCKLEN_T etc */
+#include "autoconf.h"
+/* for sockaddr_storage */
+#include "port-sockets.h"
+/* for "inline" if needed */
+#include "k5-platform.h"
+
+/*
+ * There's a lot of confusion between pointers to different sockaddr
+ * types, and pointers with different degrees of indirection, as in
+ * the locate_kdc type functions.  Use these function to ensure we
+ * don't do something silly like cast a "sockaddr **" to a
+ * "sockaddr_in *".
+ *
+ * The casts to (void *) are to get GCC to shut up about alignment
+ * increasing.
+ */
+static inline struct sockaddr_in *sa2sin (struct sockaddr *sa)
+{
+    return (struct sockaddr_in *) (void *) sa;
+}
+static inline struct sockaddr_in6 *sa2sin6 (struct sockaddr *sa)
+{
+    return (struct sockaddr_in6 *) (void *) sa;
+}
+static inline struct sockaddr *ss2sa (struct sockaddr_storage *ss)
+{
+    return (struct sockaddr *) ss;
+}
+static inline struct sockaddr_in *ss2sin (struct sockaddr_storage *ss)
+{
+    return (struct sockaddr_in *) ss;
+}
+static inline struct sockaddr_in6 *ss2sin6 (struct sockaddr_storage *ss)
+{
+    return (struct sockaddr_in6 *) ss;
+}
+
+/* Set the IPv4 or IPv6 port on sa to port.  Do nothing if sa is not an
+ * Internet socket. */
+static inline void
+sa_setport(struct sockaddr *sa, uint16_t port)
+{
+    if (sa->sa_family == AF_INET)
+        sa2sin(sa)->sin_port = htons(port);
+    else if (sa->sa_family == AF_INET6)
+        sa2sin6(sa)->sin6_port = htons(port);
+}
+
+/* Get the Internet port number of sa, or 0 if it is not an Internet socket. */
+static inline uint16_t
+sa_getport(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET)
+        return ntohs(sa2sin(sa)->sin_port);
+    else if (sa->sa_family == AF_INET6)
+        return ntohs(sa2sin6(sa)->sin6_port);
+    else
+        return 0;
+}
+
+/* Return true if sa is an IPv4 or IPv6 socket address. */
+static inline int
+sa_is_inet(struct sockaddr *sa)
+{
+    return sa->sa_family == AF_INET || sa->sa_family == AF_INET6;
+}
+
+/* Return true if sa is an IPv4 or IPv6 wildcard address. */
+static inline int
+sa_is_wildcard(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET6)
+        return IN6_IS_ADDR_UNSPECIFIED(&sa2sin6(sa)->sin6_addr);
+    else if (sa->sa_family == AF_INET)
+        return sa2sin(sa)->sin_addr.s_addr == INADDR_ANY;
+    return 0;
+}
+
+/* Return the length of an IPv4 or IPv6 socket structure; abort if it is
+ * neither. */
+static inline socklen_t
+sa_socklen(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET6)
+        return sizeof(struct sockaddr_in6);
+    else if (sa->sa_family == AF_INET)
+        return sizeof(struct sockaddr_in);
+    else
+        abort();
+}
+
+#endif /* SOCKET_UTILS_H */


### PR DESCRIPTION
Passwords piped to kinit in shell can potentially break the shell pipe.

By using a kinit API instead, such issues can be avoided.

Testing:
$ ./credentials-fetcherd  --aws_sm_secret_name aws/directoryservices/d-xxxxxxx/gmsa & $ ./api/tests/gmsa_test_client

*Issue #, if available:*
This is a fix for https://github.com/aws/credentials-fetcher/issues/31

*Description of changes:*
The kinit code is derived from kinit.c and the rest from the krb5 code base to invoke kinit using an API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
