### PR TITLE
update README.md for EPEL and dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,14 @@ This daemon works in a similar way as ccg.exe and the gMSA plugin in Windows as 
 ### How to install and run
 
 On [Fedora 36](_https://alt.fedoraproject.org/cloud/_) and similar distributions, the binary RPM can be installed as
-`sudo yum install credentials-fetcher`.
+`sudo dnf install credentials-fetcher`.
+You can also use yum if dnf is not present.
 The daemon can be started using `sudo systemctl start credentials-fetcher`.
+
+On Enterprise Linux 9 ( RHEL | CentOS | AlmaLinux ), the binary can be installed from EPEL. To add EPEL, see the [EPEL Quickstart](_https://docs.fedoraproject.org/en-US/epel/#_quickstart_).
+Once EPEL is enabled, install credentials-fetcher with 
+`sudo dnf install credentials-fetcher`.
+
 For other linux distributions, the daemon binary needs to be built from source code.
 
 ## Development


### PR DESCRIPTION
*Description of changes:*
Update the README.md to:

- Use dnf in the Fedora install string instead of yum (yum is rather obsolete and not always present in modern Fedora)
- Add instructions for installing on Enterprise Linux 9 via EPEL

Note that it will take 7 days for the EPEL-9 build to show up in the EPEL repository, so you may want to wait to merge until that happens:
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-8be81b7e72

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
