### PR TITLE
Add support to create tickets for credspec

### DIFF
--- a/api/tests/gmsa_test_client.cpp
+++ b/api/tests/gmsa_test_client.cpp
@@ -494,8 +494,17 @@ int main( int argc, char** argv )
         }
         else if ( arg == "--create" )
         {
-            std::cout << "krb tickets will get created" << std::endl;
-            create_krb_ticket( client, credspec_contents );
+            if ( i + 1 < argc )
+            {
+                std::list<std::string> credspecs = {argv[i + 1]};
+                create_krb_ticket( client, credspecs );
+                i++;
+            }
+            else
+            {
+                std::cout << "krb tickets will get created" << std::endl;
+                create_krb_ticket( client, credspec_contents );
+            }
         }
         else if ( arg == "--invalidargs" )
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added support to pass user defined credentialspec as command line arg

[root@ip-x-x-x-x tests]# ./gmsa_test_client --create '{"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"Sid":"S-1-5-21-4217655605-3681839426-3493040985","MachineAccountName":"WebApp01","Guid":"af602f85-d754-4eea-9fa8-fd76810485f1","DnsTreeName":"contoso.com","DnsName":"contoso.com","NetBiosName":"contoso"},"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApp01","Scope":"contoso.com"},{"Name":"WebApp01","Scope":"contoso"}]}}'
created ticket file /var/credentials-fetcher/krbdir/9bbd86f9f7fd4e0e4c34/WebApp01
Client received output for add kerberos lease: 9bbd86f9f7fd4e0e4c34


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
