### PR TITLE
Fix krb ticket renewal in non domainjoined mode

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -154,6 +154,8 @@ class CredentialsFetcherImpl final
                         {
                             status = get_user_krb_ticket( krb_ticket->domain_name,
                                                           aws_sm_secret_name, cf_logger );
+                            krb_ticket->domainless_user =
+                                "awsdomainlessusersecret:"+aws_sm_secret_name;
                         }
                         else
                         {

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -65,9 +65,20 @@ int krb_ticket_renew_handler( creds_fetcher::Daemon cf_daemon )
                                 krb_cc_name, cf_logger );
                             if ( gmsa_ticket_result.first != 0 )
                             {
+                                int status = -1;
                                 cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket" );
-                                int status =
-                                    get_machine_krb_ticket( krb_ticket->domain_name, cf_logger );
+                                if (domainless_user.find("awsdomainlessusersecret") !=
+                                                           std::string::npos) {
+                                    int pos = domainless_user.find(":");
+                                    std::string domainlessUser = domainless_user.substr(pos + 1);
+                                    status = get_user_krb_ticket(krb_ticket->domain_name,
+                                                                  domainlessUser, cf_logger );
+                                }
+                                else
+                                {
+                                    status = get_machine_krb_ticket( krb_ticket->domain_name,
+                                                                         cf_logger );
+                                }
                                 if ( status < 0 )
                                 {
                                     cf_logger.logger( LOG_ERR,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Fix krb ticket renewal in non domainjoined mode
    
    Validated the renewal flow with non-domain mode
    Added logic to store the the domainless user in the cache
    
    Testing:
    1. Run the credentials fetcher daemon as ./credentials-fetcherd
       --aws_sm_secret_name "ADuser"
    2. Create a kerberos ticket using ./gmsa_test_client --create
    3. Wait for renewal to start ensure the ticket is renewed
    4. Invoke the credentials-fetcher client
    ./gmsa_test_client --renew-non-domainjoined-lease "username" "password"
    "domain"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
