### PR TITLE
Add input validation domain

### DIFF
--- a/common/daemon.h
+++ b/common/daemon.h
@@ -158,6 +158,7 @@ int parse_config_file( creds_fetcher::Daemon& cf_daemon );
 /**
  * Methods in api module
  */
+bool contains_invalid_characters_in_credentials( const std::string& value );
 int RunGrpcServer( std::string unix_socket_dir, std::string krb_file_path,
                    creds_fetcher::CF_logger& cf_logger, volatile sig_atomic_t* shutdown_signal,
                    std::string aws_sm_secret_name );


### PR DESCRIPTION
*Issue #, if available:*
validate domain for invalid characters
*Description of changes:*
[root@ip-x-x-x-x tests]# ./gmsa_test_client --create_kerberos_tickets_non_domain_joined sai.akula xxxxx contoso$.com
krb tickets will get created
13: Error: invalid domainName

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
