### PR TITLE
Minification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,11 @@ target_include_directories(credentials-fetcherd PUBLIC common)
 if(${DISTRO_ID} MATCHES "ubuntu")
 	message(STATUS "Linux distro detected as ubuntu")
 target_link_libraries(credentials-fetcherd
-        PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private
+        PUBLIC systemd krb5 glib-2.0 cf_gmsa_service_private
         crypto protobuf kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto com_err krb5support resolv utf8_validity)
 else()
 target_link_libraries(credentials-fetcherd
-        PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private
+        PUBLIC systemd krb5 glib-2.0 cf_gmsa_service_private
         crypto
         kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
         com_err krb5support resolv)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,11 +137,11 @@ if(${DISTRO_ID} MATCHES "ubuntu")
 	message(STATUS "Linux distro detected as ubuntu")
 target_link_libraries(credentials-fetcherd
         PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private
-        boost_filesystem boost_system crypto protobuf kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto com_err krb5support resolv utf8_validity)
+        crypto protobuf kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto com_err krb5support resolv utf8_validity)
 else()
 target_link_libraries(credentials-fetcherd
         PUBLIC systemd boost_program_options krb5 glib-2.0 cf_gmsa_service_private
-        boost_filesystem boost_system crypto
+        crypto
         kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
         com_err krb5support resolv)
 endif()

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -60,7 +60,7 @@ if(${DISTRO_ID} MATCHES "ubuntu")
 grpc++_reflection grpc++ protobuf grpc re2 upb_json_lib upb_textformat_lib upb_collections_lib upb utf8_range_lib z absl_statusor cares gpr absl_status absl_strerror absl_flags absl_flags_internal absl_flags_reflection absl_raw_hash_set absl_hash absl_city absl_bad_variant_access absl_low_level_hash absl_hashtablez_sampler absl_flags_config absl_flags_program_name absl_flags_private_handle_accessor absl_flags_commandlineflag absl_flags_commandlineflag_internal absl_flags_marshalling absl_random_distributions absl_random_seed_sequences absl_random_internal_pool_urbg absl_random_internal_randen absl_random_internal_randen_hwaes absl_random_internal_randen_hwaes_impl absl_random_internal_randen_slow absl_random_internal_platform absl_random_internal_seed_material absl_random_seed_gen_exception absl_cord absl_bad_optional_access absl_cordz_info absl_cord_internal absl_cordz_functions absl_exponential_biased absl_cordz_handle absl_crc_cord_state absl_crc32c absl_crc_internal absl_crc_cpu_detect absl_str_format_internal absl_synchronization absl_stacktrace absl_symbolize absl_debugging_internal absl_demangle_internal absl_graphcycles_internal absl_kernel_timeout_internal absl_malloc_internal absl_time absl_strings absl_int128 absl_string_view absl_throw_delegate absl_strings_internal absl_base absl_spinlock_wait -lrt absl_raw_logging_internal absl_log_severity absl_civil_time absl_time_zone ssl crypto address_sorting
         systemd
         glib-2.0
-        boost_filesystem
+        jsoncpp
         krb5 kadm5srv_mit kdb5 gssapi_krb5 gssrpc
 	kdb5 gssrpc k5crypto com_err krb5support resolv utf8_validity
 	absl_log_internal_check_op absl_leak_check absl_die_if_null absl_log_internal_conditions absl_log_internal_message absl_examine_stack absl_log_internal_format absl_log_internal_proto absl_log_internal_nullguard absl_log_internal_log_sink_set absl_log_sink absl_log_entry absl_flags absl_flags_internal absl_flags_marshalling absl_flags_reflection absl_flags_private_handle_accessor absl_flags_commandlineflag absl_flags_commandlineflag_internal absl_flags_config absl_flags_program_name absl_log_initialize absl_log_globals absl_log_internal_globals absl_raw_hash_set absl_hash absl_city absl_low_level_hash absl_hashtablez_sampler absl_statusor absl_status absl_cord absl_cordz_info absl_cord_internal absl_cordz_functions absl_exponential_biased absl_cordz_handle absl_crc_cord_state absl_crc32c absl_crc_internal absl_crc_cpu_detect absl_bad_optional_access absl_str_format_internal absl_strerror absl_synchronization absl_graphcycles_internal absl_kernel_timeout_internal absl_stacktrace absl_symbolize absl_debugging_internal absl_demangle_internal absl_malloc_internal absl_time absl_civil_time absl_time_zone absl_bad_variant_access utf8_validity utf8_range absl_strings absl_string_view absl_strings_internal absl_base rt absl_spinlock_wait absl_int128 absl_throw_delegate absl_raw_logging_internal absl_log_severity)
@@ -71,7 +71,7 @@ else()
         ${_GRPC_GRPCPP}
         systemd
         glib-2.0
-        boost_filesystem
+        jsoncpp
         krb5 kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
         com_err krb5support resolv)
 endif()

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -1,5 +1,5 @@
 #include "daemon.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <dirent.h>
 #include <openssl/crypto.h>
 #include <sys/stat.h>
@@ -800,11 +800,11 @@ std::list<std::string> renew_kerberos_tickets_domainless(std::string krb_files_d
     std::list<std::string> renewed_krb_ticket_paths;
     // identify the metadata files in the krb directory
     std::vector<std::string> metadatafiles;
-    for ( boost::filesystem::recursive_directory_iterator end, dir( krb_files_dir );
+    for ( std::filesystem::recursive_directory_iterator end, dir( krb_files_dir );
           dir != end; ++dir )
     {
         auto path = dir->path();
-        if ( boost::filesystem::is_regular_file( path ) )
+        if ( std::filesystem::is_regular_file( path ) )
         {
             // find the file with metadata extension
             std::string filename = path.filename().string();
@@ -940,7 +940,7 @@ std::vector<std::string> delete_krb_tickets( std::string krb_files_dir, std::str
             closedir( curr_dir );
 
             // finally delete lease file and directory
-            boost::filesystem::remove_all( krb_tickets_path );
+            std::filesystem::remove_all( krb_tickets_path );
         }
     }
     catch ( ... )

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -379,7 +379,7 @@ static std::pair<size_t, void*> find_password( std::string ldap_search_result )
     std::vector<std::string> results;
 
     std::string password = std::string( "msDS-ManagedPassword::" );
-    split_string(ldap_search_result, '#', results);
+    results = split_string(ldap_search_result, '#');
     bool password_found = false;
     for ( auto& result : results )
     {
@@ -541,7 +541,7 @@ std::pair<int, std::vector<std::string>> get_domain_ips( std::string domain_name
         return std::make_pair( ips.first, list_of_ips );
     }
 
-    split_string(ips.second, '\n', list_of_ips);
+    list_of_ips = split_string(ips.second, '\n');
 
     return std::make_pair( EXIT_SUCCESS, list_of_ips );
 }
@@ -569,7 +569,7 @@ std::pair<int, std::string> get_fqdn_from_domain_ip( std::string domain_ip,
     }
 
     std::vector<std::string> list_of_dc_names;
-    split_string(reverse_dns_output.second, '\n', list_of_dc_names);
+    list_of_dc_names = split_string(reverse_dns_output.second, '\n');
     for ( auto fqdn_str : list_of_dc_names )
     {
         if ( fqdn_str.length() == 0 )
@@ -616,7 +616,7 @@ std::pair<int, std::string> get_gmsa_krb_ticket( std::string domain_name,
         return std::make_pair( -1, std::string( "" ) );
     }
 
-    split_string(domain_name, '.', results);
+    results = split_string(domain_name, '.');
     std::string base_dn; /* Distinguished name */
     for ( auto& result : results )
     {
@@ -733,7 +733,7 @@ bool is_ticket_ready_for_renewal( std::string krb_cc_name )
 
     std::vector<std::string> results;
 
-    split_string(krb_ticket_info_result.second, '#', results);
+    results = split_string(krb_ticket_info_result.second, '#');
     std::string renew_until = "renew until";
     bool is_ready_for_renewal = false;
 
@@ -962,7 +962,7 @@ std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name)
     while ( std::getline( config_file, line ) )
     {
         // TBD: Error handling for incorrectly formatted /etc/ecs/ecs.config
-        split_string(line, '=', results);
+        results = split_string(line, '=');
         std::string key = results[0];
         std::string value = results[1];
         if ( ecs_variable_name.compare( key ) == 0 )
@@ -979,16 +979,18 @@ std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name)
  * 
  * @param input_string - input string to split
  * @param delimiter - char to split the input string on
- * @param results - results to strore vector of strings after `input_string` is split
+ * @return results - results to store vector of strings after `input_string` is split
 */
-void split_string(std::string input_string, char delimiter, std::vector<std::string> results)
+std::vector<std::string> split_string(std::string input_string, char delimiter)
 {
+    std::vector<std::string> results;
     std::istringstream input_string_stream(input_string);
     std::string token;
     while (std::getline(input_string_stream, token, delimiter))
     {
         results.push_back(token);
     }
+    return results;
 }
 
 /**

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -154,7 +154,7 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
 
 int parse_config_file( creds_fetcher::Daemon& cf_daemon );
 std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name);
-void split_string(std::string input_string, char delimiter, std::vector<std::string> results);
+std::vector<std::string> split_string(std::string input_string, char delimiter);
 
 /**
  * Methods in api module

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -1,5 +1,4 @@
 #include "config.h"
-#include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <json/json.h>
 #include <csignal>
@@ -155,6 +154,7 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
 
 int parse_config_file( creds_fetcher::Daemon& cf_daemon );
 std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name);
+void split_string(std::string input_string, char delimiter, std::vector<std::string> results);
 
 /**
  * Methods in api module

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -1,7 +1,7 @@
 #include "config.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include <json/json.h>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -1,5 +1,4 @@
 #include "config.h"
-#include <boost/program_options.hpp>
 #include <json/json.h>
 #include <csignal>
 #include <cstddef>
@@ -16,6 +15,10 @@
 #include <thread>
 #include <unistd.h>
 #include <vector>
+#include <getopt.h>
+#include <iomanip>
+#include <map>
+#include <algorithm>
 
 #ifndef _daemon_h_
 #define _daemon_h_

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -1,6 +1,51 @@
 #include "daemon.h"
 
 /**
+ * This function prints formatted help descriptions
+ * @param long_options - option struct passed to getopt_log method
+ * @param long_options - map of commnad line arg and its description
+ */
+void print_help( const struct option* long_options,
+                 const std::map<std::string, std::string>& options_descriptions )
+{
+    std::cout << "Usage: " << std::endl;
+    std::cout << " Allowed options [OPTION...]" << std::endl;
+    size_t max_option_length = 0;
+    for ( const struct option* opt = long_options; opt->name != nullptr; ++opt )
+    {
+        size_t option_length =
+            opt->has_arg == required_argument ? strlen( opt->name ) + 5 : strlen( opt->name ) + 2;
+        if ( option_length > max_option_length )
+        {
+            max_option_length = option_length;
+        }
+    }
+    for ( const struct option* opt = long_options; opt->name != nullptr; ++opt )
+    {
+        std::string opt_string;
+        if ( opt->val != 0 )
+        {
+            opt_string = std::string( "--" ) + opt->name;
+        }
+        else
+        {
+            opt_string = std::string( "--" ) + opt->name;
+        }
+        std::string description;
+        if ( options_descriptions.count( opt->name ) > 0 )
+        {
+            description = options_descriptions.at( opt->name );
+        }
+        else
+        {
+            description = opt->name;
+        }
+        std::cout << "  " << std::left << std::setw( max_option_length ) << opt_string << "\t"
+                  << description << std::endl;
+    }
+}
+
+/**
  * This function has options used to invoke the daemon such as
  * credentials-fetcherd --configfile path-to-file
  * @param argc - argc from command line input
@@ -14,57 +59,50 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
     try
     {
         std::string domainless_gmsa_field( "CREDENTIALS_FETCHER_SECRET_NAME_FOR_DOMAINLESS_GMSA" );
-        namespace po = boost::program_options;
-
-        /* Declare the supported options */
-        po::options_description desc( "Allowed options" );
-        desc.add_options()( "help", "produce help message" ) /* TBD: Add help message description */
-            ( "self_test", "Run tests such as utf16 decode" )( "verbosity", po::value<int>(),
-                                                               "set verbosity level" )(
-                "aws_sm_secret_name", po::value<std::string>(), // TBD:: Extend to other stores
-                "Name of secret containing username/password in AWS Secrets Manager (in same "
-                "region)" );
-
-        /**
-         * Calls to store, parse_command_line and notify functions
-         * cause the vm variable to contain all the options found on the command line
-         */
-        po::variables_map vm;
-        po::store( po::parse_command_line( argc, argv, desc ), vm );
-        po::notify( vm );
-
-        if ( vm.count( "help" ) )
+        struct option long_options[] = { { "help", no_argument, nullptr, 'h' },
+                                         { "self_test", no_argument, nullptr, 't' },
+                                         { "verbosity", required_argument, nullptr, 'v' },
+                                         { "aws_sm_secret_name", required_argument, nullptr, 's' },
+                                         { nullptr, 0, nullptr, 0 } };
+        std::map<std::string, std::string> options_descriptions{
+            { "help", "produce help message" },
+            { "self_test", "Run tests such as utf16 decode" },
+            { "verbosity", "set verbosity level" },
+            { "aws_sm_secret_name", "Name of secret containing username/password in AWS Secrets "
+                                    "Manager (in same region)" } };
+        int option;
+        while ( ( option = getopt_long( argc, (char* const*)argv, "htv:s:", long_options, nullptr ) ) != -1 )
         {
-            std::cout << desc << "\n";
-            return EXIT_FAILURE;
-        }
-
-        if ( vm.count( "verbosity" ) )
-        {
-            std::cout << "verbosity level was set to " << vm["verbosity"].as<int>() << std::endl;
-        }
-
-        if ( vm.count( "self_test" ) )
-        {
-            std::cout << "run diagnostic set" << std::endl;
-            cf_daemon.run_diagnostic = true;
-        }
-
-        if ( vm.count( "aws_sm_secret_name" ) ) // TBD:: Extend to other stores
-        {
-            cf_daemon.aws_sm_secret_name = vm["aws_sm_secret_name"].as<std::string>();
-            std::cout
-                << "Option selected for domainless operation, AWS secrets manager secret-name = "
-                << cf_daemon.aws_sm_secret_name << std::endl;
+            switch ( option )
+            {
+            case 'h':
+                print_help( long_options, options_descriptions );
+                return EXIT_FAILURE;
+            case 't':
+                std::cout << "run diagnostic set" << std::endl;
+                cf_daemon.run_diagnostic = true;
+                break;
+            case 'v':
+                std::cout << "Verbosity level was set to " << optarg << std::endl;
+                break;
+            case 's':
+                cf_daemon.aws_sm_secret_name = optarg;
+                std::cout << "Option selected for domainless operation, AWS secrets manager "
+                             "secret-name = " << optarg << std::endl;
+                break;
+            default:
+                std::cout << "Run with --help to see options" << std::endl;
+                return EXIT_FAILURE;
+            }
         }
         std::string aws_sm_secret_name = retrieve_secret_from_ecs_config(domainless_gmsa_field);
         cf_daemon.aws_sm_secret_name = aws_sm_secret_name;
     }
-    catch ( const boost::program_options::error& ex )
+    catch ( const std::exception& ex )
     {
         std::cout << "Run with --help to see options" << std::endl;
         return EXIT_FAILURE;
     }
-
+    
     return EXIT_SUCCESS;
 }

--- a/metadata/src/metadata.cpp
+++ b/metadata/src/metadata.cpp
@@ -1,12 +1,10 @@
 #include "daemon.h"
-#include <boost/filesystem.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
 static const std::vector<char> invalid_path_characters = {
-    '&', ':', '\\', '|', '*', '?', '<', '>', '`', '$', '{', '}', '(', ')', '"' ,';'};
+    '&', ':', '\\', '|', '*', '?', '<', '>', '`', '$', '{', '}', '(', ')', '"', ';' };
 /**
  *
  * @param path - string input that has to be validated
@@ -45,34 +43,41 @@ std::list<creds_fetcher::krb_ticket_info*> read_meta_data_json( std::string file
         }
 
         // deserialize json to krb_ticket_info object
-        namespace pt = boost::property_tree;
-        pt::ptree root;
-        pt::read_json( file_path, root );
+        Json::Value root;
+        std::ifstream json_file( file_path );
 
-        const pt::ptree& child_tree_krb_info = root.get_child( "krb_ticket_info" );
-
-        for ( const auto& kv : child_tree_krb_info )
+        if ( json_file.is_open() )
         {
-            creds_fetcher::krb_ticket_info* krb_ticket_info = new creds_fetcher::krb_ticket_info;
-            std::string krb_file_path = kv.second.get<std::string>( "krb_file_path" );
+            json_file >> root;
+            json_file.close();
 
-            if ( contains_invalid_characters( krb_file_path ) )
+            // deserialize json to krb_ticket_info object
+            const Json::Value& child_tree_krb_info = root["krb_ticket_info"];
+
+            for ( const Json::Value& krb_info : child_tree_krb_info )
             {
-                fprintf( stderr, SD_CRIT "krb file path contains invalid characters" );
-                free( krb_ticket_info );
-                break;
-            }
+                creds_fetcher::krb_ticket_info* krb_ticket_info =
+                    new creds_fetcher::krb_ticket_info;
+                std::string krb_file_path = krb_info["krb_file_path"].asString();
 
-            // only add path if it exists
-            if ( boost::filesystem::exists( krb_file_path ) )
-            {
-                krb_ticket_info->krb_file_path = krb_file_path;
-                krb_ticket_info->service_account_name =
-                    kv.second.get<std::string>( "service_account_name" );
-                krb_ticket_info->domain_name = kv.second.get<std::string>( "domain_name" );
-                krb_ticket_info->domainless_user = kv.second.get<std::string>( "domainless_user" );
+                if ( contains_invalid_characters( krb_file_path ) )
+                {
+                    fprintf( stderr, SD_CRIT "krb file path contains invalid characters" );
+                    free( krb_ticket_info );
+                    break;
+                }
 
-                krb_ticket_info_list.push_back( krb_ticket_info );
+                // only add path if it exists
+                if ( std::filesystem::exists( krb_file_path ) )
+                {
+                    krb_ticket_info->krb_file_path = krb_file_path;
+                    krb_ticket_info->service_account_name =
+                        krb_info["service_account_name"].asString();
+                    krb_ticket_info->domain_name = krb_info["domain_name"].asString();
+                    krb_ticket_info->domainless_user = krb_info["domainless_user"].asString();
+
+                    krb_ticket_info_list.push_back( krb_ticket_info );
+                }
             }
         }
     }
@@ -115,26 +120,38 @@ int write_meta_data_json( std::list<creds_fetcher::krb_ticket_info*> krb_ticket_
         std::string file_path = krb_files_dir + "/" + lease_id + "/" + meta_file_name;
 
         // create the meta file in the lease directory
-        boost::filesystem::path dirPath( file_path );
-        boost::filesystem::create_directories( dirPath.parent_path() );
+        std::filesystem::path dirPath( file_path );
+        std::filesystem::create_directories( dirPath.parent_path() );
 
         // parse the kerberos info and serialize to json
-        boost::property_tree::ptree root;
-        boost::property_tree::ptree krb_ticket_info_parent;
+        Json::Value root;
+        Json::Value krb_ticket_info_parent;
 
         for ( auto krb_ticket_info : krb_ticket_info_list )
         {
-            boost::property_tree::ptree ticket_info;
-            ticket_info.put( "krb_file_path", krb_ticket_info->krb_file_path );
-            ticket_info.put( "service_account_name", krb_ticket_info->service_account_name );
-            ticket_info.put( "domain_name", krb_ticket_info->domain_name );
-            ticket_info.put( "domainless_user", krb_ticket_info->domainless_user );
+            Json::Value ticket_info;
+            ticket_info["krb_file_path"] = krb_ticket_info->krb_file_path;
+            ticket_info["service_account_name"] = krb_ticket_info->service_account_name;
+            ticket_info["domain_name"] = krb_ticket_info->domain_name;
+            ticket_info["domainless_user"] = krb_ticket_info->domainless_user;
 
-            krb_ticket_info_parent.push_back( std::make_pair( "", ticket_info ) );
+            krb_ticket_info_parent.append( ticket_info );
         }
 
-        root.add_child( "krb_ticket_info", krb_ticket_info_parent );
-        boost::property_tree::write_json( file_path, root );
+        root["krb_ticket_info"] = krb_ticket_info_parent;
+
+        Json::StreamWriterBuilder writer;
+        std::string jsonString = Json::writeString( writer, root );
+        std::ofstream json_file( file_path );
+        if ( json_file.is_open() )
+        {
+            json_file << jsonString;
+            json_file.close();
+        }
+        else
+        {
+            std::cerr << "Failed to write JSON file: " << file_path << std::endl;
+        }
     }
     catch ( const std::exception& ex )
     {

--- a/metadata/tests/metadata_test.cpp
+++ b/metadata/tests/metadata_test.cpp
@@ -1,5 +1,6 @@
 #include "daemon.h"
 #include <filesystem>
+#include <fstream>
 
 int read_meta_data_json_test()
 {

--- a/metadata/tests/metadata_test.cpp
+++ b/metadata/tests/metadata_test.cpp
@@ -1,5 +1,5 @@
 #include "daemon.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 int read_meta_data_json_test()
 {
@@ -12,10 +12,10 @@ int read_meta_data_json_test()
     for ( auto file_path : paths )
     {
         // create the meta file in the lease directory
-        boost::filesystem::path dirPath( file_path );
-        boost::filesystem::create_directories( dirPath.parent_path() );
+        std::filesystem::path dirPath( file_path );
+        std::filesystem::create_directories( dirPath.parent_path() );
 
-        if ( !boost::filesystem::exists( file_path ) )
+        if ( !std::filesystem::exists( file_path ) )
         {
             std::ofstream file( file_path );
             file.close();
@@ -29,7 +29,7 @@ int read_meta_data_json_test()
         std::cout << "reading meta data file test is failed" << std::endl;
         for ( auto file_path : paths )
         {
-           boost::filesystem::remove_all(file_path );
+           std::filesystem::remove_all(file_path );
         }
         return EXIT_FAILURE;
     }
@@ -37,7 +37,7 @@ int read_meta_data_json_test()
     std::cout << "read meta data file test is successful" << std::endl;
     for ( auto file_path : paths )
     {
-        boost::filesystem::remove_all(file_path );
+        std::filesystem::remove_all(file_path );
     }
     return EXIT_SUCCESS;
 }
@@ -68,10 +68,10 @@ int write_meta_data_json_test()
     for ( auto file_path : paths )
     {
         // create the meta file in the lease directory
-        boost::filesystem::path dirPath( file_path );
-        boost::filesystem::create_directories( dirPath.parent_path() );
+        std::filesystem::path dirPath( file_path );
+        std::filesystem::create_directories( dirPath.parent_path() );
 
-        if ( !boost::filesystem::exists( file_path ) )
+        if ( !std::filesystem::exists( file_path ) )
         {
             std::ofstream file( file_path );
             file.close();
@@ -91,18 +91,18 @@ int write_meta_data_json_test()
         std::cout << "write meta data to file test is failed" << std::endl;
         for ( auto file_path : paths )
         {
-            boost::filesystem::remove_all(file_path );
+            std::filesystem::remove_all(file_path );
         }
         return EXIT_FAILURE;
     }
 
     // finally delete test lease directory
-    boost::filesystem::remove_all( krb_files_dir + "/" + test_lease_id );
+    std::filesystem::remove_all( krb_files_dir + "/" + test_lease_id );
 
     std::cout << "write meta data info to file test is successful" << std::endl;
     for ( auto file_path : paths )
     {
-        boost::filesystem::remove_all(file_path );
+        std::filesystem::remove_all(file_path );
     }
     return EXIT_SUCCESS;
 }

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -14,7 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/aws/credentials-fetcher
 Source0:        https://github.com/aws/credentials-fetcher/archive/refs/tags/v.%{version}.tar.gz
  
-BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel boost-program-options jsoncpp-devel
+BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel jsoncpp-devel
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
 BuildRequires:  systemd-rpm-macros dotnet-sdk-6.0 grpc-plugins
  

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -14,11 +14,11 @@ License:        Apache-2.0
 URL:            https://github.com/aws/credentials-fetcher
 Source0:        https://github.com/aws/credentials-fetcher/archive/refs/tags/%{version}.tar.gz
 
-BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel boost-devel
+BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel boost-program-options jsoncpp-devel
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
 BuildRequires:  systemd-rpm-macros dotnet-sdk-6.0 grpc-plugins
 
-Requires: bind-utils openldap openldap-clients awscli dotnet-runtime-6.0
+Requires: bind-utils openldap openldap-clients awscli dotnet-runtime-6.0 jsoncpp-devel jsoncpp
 
 # No one likes you i686
 ExcludeArch:    i686 armv7hl

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -1,5 +1,5 @@
 #include "daemon.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <chrono>
 #include <stdlib.h>
 
@@ -25,11 +25,11 @@ int krb_ticket_renew_handler( creds_fetcher::Daemon cf_daemon )
 
             // identify the metadata files in the krb directory
             std::vector<std::string> metadatafiles;
-            for ( boost::filesystem::recursive_directory_iterator end, dir( krb_files_dir );
+            for ( std::filesystem::recursive_directory_iterator end, dir( krb_files_dir );
                   dir != end; ++dir )
             {
                 auto path = dir->path();
-                if ( boost::filesystem::is_regular_file( path ) )
+                if ( std::filesystem::is_regular_file( path ) )
                 {
                     // find the file with metadata extension
                     std::string filename = path.filename().string();


### PR DESCRIPTION
## Issue
* The size of credentials-fetcher RPM is higher than the desired value
* Credentials-fetcher has a dependency on Boost which can be replaced with smaller packages

## Solution
* Replace all `boost` usages for JSON manipulation with [JsonCpp](http://open-source-parsers.github.io/jsoncpp-docs/doxygen/index.html) 
* Replace all `boost` directory operation with standard [Filesystem ](https://en.cppreference.com/w/cpp/filesystem) library
* Replace all `boost` string operations with standard string library
* Replace all `boost-progarm-options` usages with [`getopt`](https://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html) library
* Update CMake to build the new libraries replacing Boost