### PR TITLE
fixing ticket renewal not executing in domainless mode and expiration timestamp logic

### DIFF
--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -815,7 +815,7 @@ std::string get_ticket_expiration( std::string klist_ticket_info )
         }
     }
 
-    return klist_expires_date;
+    return klist_expires_date + " " + klist_expires_time;
 }
 
 int test_get_ticket_expiration()
@@ -835,8 +835,8 @@ int test_get_ticket_expiration()
 			renew until 12/11/23 21:58:51\n\
 			12/04/23 21:58:51  12/05/23 07:58:51  EC2AMAZ-4MQOKF$@CUSTOMERTEST.LOCAL" );
 
-    std::string expire_date_4_digit_year( "12/05/2023" );
-    std::string expire_date_2_digit_year( "12/05/23" );
+    std::string expire_date_4_digit_year( "12/05/2023 05:39:06" );
+    std::string expire_date_2_digit_year( "12/05/23 07:58:51" );
     bool test_4_digit_year = false;
     bool test_2_digit_year = false;
 

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -54,8 +54,10 @@ int krb_ticket_renew_handler( creds_fetcher::Daemon cf_daemon )
                     std::pair<int, std::string> gmsa_ticket_result;
                     std::string krb_cc_name = krb_ticket->krb_file_path;
                     std::string domainless_user = krb_ticket->domainless_user;
-                    // check if the ticket is ready for renewal and not created in domainless mode
-                    if ( domainless_user.empty() && is_ticket_ready_for_renewal( krb_ticket ))
+                    // check if the ticket is ready for renewal
+                    if ( (domainless_user.empty() || domainless_user.find("awsdomainlessusersecret") !=
+                                                           std::string::npos) && is_ticket_ready_for_renewal( krb_ticket ))
+
                     {
                         std::cout << "gMSA ticket is at " + krb_cc_name +
                                         " is ready for renewal!"


### PR DESCRIPTION
fixing ticket renewal not executing in domainless mode and expiration timestamp logic.