### PR TITLE
Change renewal logic for domainless

### DIFF
--- a/api/tests/gmsa_test_client.cpp
+++ b/api/tests/gmsa_test_client.cpp
@@ -251,13 +251,9 @@ class CredentialsFetcherClient
             std::list<std::string> credspec_contents, std::string accessId, std::string secretKey, std::string sessionToken, std::string region )
     {
         // Prepare request
-        credentialsfetcher::KerberosArnLeaseRequest request;
+        credentialsfetcher::RenewKerberosArnLeaseRequest request;
         std::pair<std::string, std::string> result;
-        for ( std::list<std::string>::const_iterator i = credspec_contents.begin();
-              i != credspec_contents.end(); ++i )
-        {
-            request.add_credspec_arns( i->c_str() );
-        }
+
         request.set_access_key_id(accessId);
         request.set_secret_access_key(secretKey);
         request.set_session_token(sessionToken);
@@ -399,7 +395,7 @@ static void show_usage( std::string name )
                " credspecArn, accessId, secretkey, sessionToken, region"
             << "\t --renew_kerberos_tickets_arn \t\t create tickets by getting credspecs from s3 "
                " gMSA \tprovide"
-               "credspecArn, accessId, secretkey, sessionToken, region"
+               "accessId, secretkey, sessionToken, region"
               << "\t --invalidargs \t\ttest with invalid args, failure scenario\n"
               << "\t --run_stress_test \t\tstress test with multiple accounts and leases\n"
               << std::endl;
@@ -733,11 +729,10 @@ int main( int argc, char** argv )
         else if(arg == "--renew_kerberos_tickets_arn"){
             if ( i + 3 < argc )
             {
-                credspecArn = argv[ i + 1];
-                accessId = argv[i + 2];
-                secretkey = argv[i + 3];
-                sessionToken = argv[i + 4];
-                region = argv[i + 5];
+                accessId = argv[i + 1];
+                secretkey = argv[i + 2];
+                sessionToken = argv[i + 3];
+                region = argv[i + 4];
             }
             else
             {
@@ -747,7 +742,7 @@ int main( int argc, char** argv )
                 return 0;
             }
             std::cout << "krb tickets will get created" << std::endl;
-            std::list<std::string>  domainless_arn_array = {credspecArn};
+            std::list<std::string>  domainless_arn_array = {};
             renew_krb_ticket_arns( client, credspec_contents_arns_domainless, accessId, secretkey,
                                     sessionToken, region );
             i++;

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -62,6 +62,7 @@ namespace creds_fetcher
         std::string service_account_name;
         std::string domain_name;
         std::string domainless_user;
+        std::string credspec_info;
     };
 
     /*
@@ -138,6 +139,11 @@ namespace creds_fetcher
 /**
  * Methods in auth module
  */
+std::vector<std::string>  get_meta_data_file_paths(std::string krbdir);
+std::string renew_gmsa_ticket( creds_fetcher::krb_ticket_info* krb_ticket, std::string
+                                                                               domain_name,
+                               std::string username, std::string password,
+                               creds_fetcher::CF_logger& cf_logger  );
 void truncate_log_files();
 std::string getCurrentTime();
 int generate_host_machine_krb_ticket( const char* krb_ccname = "" );

--- a/metadata/src/metadata.cpp
+++ b/metadata/src/metadata.cpp
@@ -78,6 +78,11 @@ std::list<creds_fetcher::krb_ticket_info*> read_meta_data_json( std::string file
                     krb_ticket_info->domain_name = krb_info["domain_name"].asString();
                     krb_ticket_info->domainless_user = krb_info["domainless_user"].asString();
 
+                    if(krb_info.isMember("credspec_info"))
+                    {
+                        krb_ticket_info->credspec_info = krb_info["credspec_info"].asString();
+                    }
+
                     krb_ticket_info_list.push_back( krb_ticket_info );
                 }
             }
@@ -153,6 +158,7 @@ int write_meta_data_json( std::list<creds_fetcher::krb_ticket_info*> krb_ticket_
             ticket_info["service_account_name"] = krb_ticket_info->service_account_name;
             ticket_info["domain_name"] = krb_ticket_info->domain_name;
             ticket_info["domainless_user"] = krb_ticket_info->domainless_user;
+            ticket_info["credspec_info"] = krb_ticket_info->credspec_info;
 
             krb_ticket_info_parent.append( ticket_info );
         }

--- a/protos/credentialsfetcher.proto
+++ b/protos/credentialsfetcher.proto
@@ -12,7 +12,7 @@ service CredentialsFetcherService {
     rpc DeleteKerberosLease (DeleteKerberosLeaseRequest) returns (DeleteKerberosLeaseResponse);
     rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
     rpc AddKerberosArnLease (KerberosArnLeaseRequest) returns (CreateKerberosArnLeaseResponse);
-    rpc RenewKerberosArnLease (KerberosArnLeaseRequest) returns (RenewKerberosArnLeaseResponse);
+    rpc RenewKerberosArnLease (RenewKerberosArnLeaseRequest) returns (RenewKerberosArnLeaseResponse);
 }
 
 message HealthCheckRequest {
@@ -29,6 +29,13 @@ message KerberosArnLeaseRequest {
     string secret_access_key = 3;
     string session_token = 4;
     string region = 5;
+}
+
+message RenewKerberosArnLeaseRequest {
+    string access_key_id = 1;
+    string secret_access_key = 2;
+    string session_token = 3;
+    string region = 4;
 }
 
 message CreateKerberosArnLeaseResponse {


### PR DESCRIPTION
*Description of changes:*
change for the renewal logic domainless mode

Testing:
[root@EC2AMAZ-7ZXeXp tests]# ./gmsa_test_client --create_kerberos_tickets_non_domain_joined sai.akula xxxxx contoso.com
krb tickets will get created
created ticket file /var/credentials-fetcher/krbdir/bab0f250604267d0e4b9/WebApp01
created ticket file /var/credentials-fetcher/krbdir/bab0f250604267d0e4b9/WebApp03
Client received output for add kerberos lease non domain joined: bab0f250604267d0e4b9
provide a valid arg, for help use -h or --help
[root@EC2AMAZ-7ZXeXp tests]# export KRB5CCNAME=/var/credentials-fetcher/krbdir/bab0f250604267d0e4b9/WebApp01/krb5cc
[root@EC2AMAZ-7ZXeXp tests]# klist
Ticket cache: FILE:/var/credentials-fetcher/krbdir/bab0f250604267d0e4b9/WebApp01/krb5cc
Default principal: WebApp01$@CONTOSO.COM

Valid starting     Expires            Service principal
12/12/23 19:32:53  12/12/23 20:33:53  krbtgt/CONTOSO.COM@CONTOSO.COM
        renew until 12/19/23 19:32:53
[root@EC2AMAZ-7ZXeXp tests]# ./gmsa_test_client --renew_kerberos_tickets_non_domain_joined sai.akula xxxx contoso.com
krb tickets will get renewed
kerberos ticket renewal successful
Client received output for renew kerberos lease non domain joined
provide a valid arg, for help use -h or --help
[root@EC2AMAZ-7ZXeXp tests]# klist
Ticket cache: FILE:/var/credentials-fetcher/krbdir/bab0f250604267d0e4b9/WebApp01/krb5cc
Default principal: WebApp01$@CONTOSO.COM

Valid starting     Expires            Service principal
12/12/23 19:33:16  12/12/23 20:34:16  krbtgt/CONTOSO.COM@CONTOSO.COM
        renew until 12/19/23 19:33:16


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
