### PR TITLE
Health check commandline option

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -1907,6 +1907,49 @@ int RunGrpcServer( std::string unix_socket_dir, std::string krb_files_dir,
     return 0;
 }
 
+
+/**
+ * Check health of credentials-fetcher daemon
+ * @return - int
+ */
+int HealthCheck(std::string serviceName)
+{
+    std::string server_address{ "unix:/var/credentials-fetcher/socket/credentials_fetcher.sock" };
+    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel( server_address,
+                                                                grpc::InsecureChannelCredentials());
+    std::unique_ptr<credentialsfetcher::CredentialsFetcherService::Stub> stub =  credentialsfetcher::CredentialsFetcherService::NewStub( channel );
+    std::string result;
+    // Prepare request
+    credentialsfetcher::HealthCheckRequest request;
+    request.set_service( serviceName );
+
+    credentialsfetcher::HealthCheckResponse response;
+    grpc::ClientContext context;
+    grpc::Status status;
+
+    try
+    {
+        // Send request
+        status = stub->HealthCheck( &context, request, &response );
+
+        // Handle response
+        if ( status.ok() )
+        {
+            return 0;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    catch ( ... )
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
 /**
  * Generate a random lease_id of defined length
  * @return - string

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -190,6 +190,7 @@ int renewal_failure_krb_dir_not_found_test();
  * Methods in config module
  */
 int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemon );
+int HealthCheck(std::string serviceName);
 
 int parse_config_file( creds_fetcher::Daemon& cf_daemon );
 std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name);

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -69,6 +69,7 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
                                          { "verbosity", required_argument, nullptr, 'v' },
                                          { "aws_sm_secret_name", required_argument, nullptr, 's' },
                                          { "version", no_argument, nullptr, 'n' },
+                                         { "healthcheck", no_argument, nullptr, 'c' },
                                          { nullptr, 0, nullptr, 0 } };
         std::map<std::string, std::string> options_descriptions{
             { "help", "produce help message" },
@@ -76,8 +77,10 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
             { "verbosity", "set verbosity level" },
             { "aws_sm_secret_name", "Name of secret containing username/password in AWS Secrets "
                                     "Manager (in same region)" },
+            { "healthcheck", "health of credentials-fetcher" },
             { "version", "Version of credentials-fetcher" } };
         int option;
+        int healthCheckResponse;
         while ( ( option = getopt_long( argc, (char* const*)argv, "htv:s:n", long_options, nullptr ) ) != -1 )
         {
             switch ( option )
@@ -99,6 +102,10 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
                 break;
             case 'n':
                 std::cout << CMAKE_PROJECT_VERSION << std::endl;
+                return EXIT_FAILURE;
+            case 'c':
+                healthCheckResponse = HealthCheck("test");
+                std::cout << healthCheckResponse << std::endl;
                 return EXIT_FAILURE;
             default:
                 std::cout << "Run with --help to see options" << std::endl;


### PR DESCRIPTION
*Description of changes:*
Added commandline option to check health of daemon:

Testing:
[ec2-user@EC2AMAZ-7ZXeXp build]$ sudo ./credentials-fetcherd --healthcheck // while daemon is active
0
[ec2-user@EC2AMAZ-7ZXeXp build]$ sudo ./credentials-fetcherd --healthcheck // while daemon is inactive
-1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
