### PR TITLE
Regex change for domainName field

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -477,6 +477,13 @@ class CredentialsFetcherImpl final
                             krb_ticket_arns->credential_spec_arn = results[0];
                             int parse_result = parse_cred_spec_domainless(
                                 response, krb_ticket_info, krb_ticket_arns );
+                            if(parse_result != 0)
+                            {
+                                err_msg = "ERROR: invalid credentialspec fields";
+                                          std::cout << getCurrentTime() << '\t' << err_msg
+                                          << std::endl;
+                                break;
+                            }
 
                             // only add the ticket info if the parsing is successful
                             if ( parse_result == 0 )
@@ -877,6 +884,14 @@ class CredentialsFetcherImpl final
                                 int parse_result = parse_cred_spec_domainless(
                                     response, krb_ticket_info, krb_ticket_arns );
 
+                                if(parse_result != 0)
+                                {
+                                    err_msg = "ERROR: invalid credentialspec fields";
+                                    std::cout << getCurrentTime() << '\t' << err_msg
+                                              << std::endl;
+                                    break;
+                                }
+
                                 // only add the ticket info if the parsing is successful
                                 if ( parse_result == 0 )
                                 {
@@ -1125,6 +1140,14 @@ class CredentialsFetcherImpl final
                         new creds_fetcher::krb_ticket_info;
                     int parse_result = parse_cred_spec( create_krb_request_.credspec_contents( i ),
                                                         krb_ticket_info );
+
+                    if(parse_result != 0)
+                    {
+                        err_msg = "ERROR: invalid credentialspec fields";
+                                  std::cout << getCurrentTime() << '\t' << err_msg
+                                  << std::endl;
+                        break;
+                    }
 
                     // only add the ticket info if the parsing is successful
                     if ( parse_result == 0 )
@@ -1421,6 +1444,14 @@ class CredentialsFetcherImpl final
                             int parse_result = parse_cred_spec(
                                 create_domainless_krb_request_.credspec_contents( i ),
                                 krb_ticket_info );
+
+                            if(parse_result != 0)
+                            {
+                                err_msg = "ERROR: invalid credentialspec fields";
+                                          std::cout << getCurrentTime() << '\t' << err_msg
+                                          << std::endl;
+                                break;
+                            }
 
                             // only add the ticket info if the parsing is successful
                             if ( parse_result == 0 )

--- a/api/tests/gmsa_test_client.cpp
+++ b/api/tests/gmsa_test_client.cpp
@@ -572,7 +572,7 @@ int run_stress_test( CredentialsFetcherClient& client, int num_of_leases,
 }
 
 // unit tests
-int parse_credspec_domainless_test(std::string credspec)
+bool parse_credspec_domainless_test(std::string credspec)
 {
     creds_fetcher::krb_ticket_info* krb_ticket_info =
                 new creds_fetcher::krb_ticket_info;
@@ -581,7 +581,19 @@ int parse_credspec_domainless_test(std::string credspec)
     int response = parse_cred_spec_domainless(credspec, krb_ticket_info, krb_ticket_arn_mapping );
     std::cout << krb_ticket_arn_mapping->credential_spec_arn;
     std::cout << krb_ticket_arn_mapping->krb_file_path;
-    return response;
+    if(response == 0)
+    {
+       return true;
+    }
+    return  false;
+}
+
+int validate_domain()
+{
+    return (isValidDomain("a.com") && isValidDomain("ab.toto-abc.com") &&
+             !isValidDomain("p/") && isValidDomain("test4.gmsa-pentest.com") &&
+             !isValidDomain ("-testdomain.org") &&  isValidDomain("contoso.com") &&
+             !isValidDomain(".org"));
 }
 
 #if AMAZON_LINUX_DISTRO
@@ -678,9 +690,16 @@ int main( int argc, char** argv )
         }
         else if (arg == "--unit_test")
         {
-            parse_credspec_domainless_test(credspec_contents_domainless_str);
-            //retrieve_credspec_from_s3_test();
-            return 0;
+
+            bool testStatus = (parse_credspec_domainless_test(credspec_contents_domainless_str) && validate_domain());
+            if(!testStatus){
+                std::cout << "client tests failed" << std::endl;
+                return  EXIT_FAILURE;
+            }
+            else{
+                std::cout << "client tests successful" << std::endl;
+                return  EXIT_SUCCESS;
+            }
         }
         else if ( arg == "--check" )
         {

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -1126,13 +1126,20 @@ std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name)
 
     while ( std::getline( config_file, line ) )
     {
-        // TBD: Error handling for incorrectly formatted /etc/ecs/ecs.config
         results = split_string(line, '=');
         std::string key = results[0];
         std::string value = results[1];
         if ( ecs_variable_name.compare( key ) == 0 )
         {
             value.erase( std::remove( value.begin(), value.end(), '"' ), value.end() );
+
+            if( contains_invalid_characters_in_ad_account_name(value))
+            {
+                std::cout << getCurrentTime() << '\t' << "invalid domain controller name" <<
+                    std::endl;
+                return "";
+            }
+
             return value;
         }
     }

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -85,9 +85,16 @@ namespace creds_fetcher
         {
             if ( level >= log_level )
             {
-                sd_journal_print( level, fmt, logs... );
+                std::string logFmt = fmt;
+                for (int i = 0; logFmt[i] != '\0'; ++i) {
+                    if (logFmt[i] == '\n') {
+                        logFmt[i] = ' '; // Replace '\n' with space
+                    }
+                }
+                sd_journal_print( level, logFmt.c_str(), logs... );
             }
         }
+
 
         void init_file_logger ()
         {
@@ -190,6 +197,7 @@ int renewal_failure_krb_dir_not_found_test();
  * Methods in config module
  */
 int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemon );
+bool isValidDomain(const std::string& value);
 int HealthCheck(std::string serviceName);
 
 int parse_config_file( creds_fetcher::Daemon& cf_daemon );
@@ -203,6 +211,7 @@ bool contains_invalid_characters_in_credentials( const std::string& value );
 int RunGrpcServer( std::string unix_socket_dir, std::string krb_file_path,
                    creds_fetcher::CF_logger& cf_logger, volatile sig_atomic_t* shutdown_signal,
                    std::string aws_sm_secret_name );
+bool contains_invalid_characters_in_ad_account_name( const std::string& value );
 
 int parse_cred_spec( std::string credspec_data, creds_fetcher::krb_ticket_info* krb_ticket_info );
 


### PR DESCRIPTION
*Description of changes:*
Regex validation check if the domainName is up to DNS naming standards
Testing:
int main() {
    std::cout << "test regex" << "\n";

    //std::cout << "a.com" << "\n";
    std::cout << isValidDomain("a.com") << "\n";
    //std::cout << isValidDomain("ab.com") << "\n";
    std::cout << isValidDomain("ab.toto-abc.com") << "\n"; 
    std::cout << isValidDomain("p/") << "\n";
    std::cout << isValidDomain("test4.gmsa-pentest.com") << "\n";
    std::cout << isValidDomain("-geeksforgeeks.org") << "\n";
    std::cout << isValidDomain("contoso.com") << "\n";
    std::cout << isValidDomain(".org") << "\n";
    
    return 0;
}
~                                                                                                                                                               
"regex.cpp" 49L, 1331B written
[ec2-user@EC2AMAZ-Ll40tS ~]$ g++ -o test regex.cpp 
[ec2-user@EC2AMAZ-Ll40tS ~]$ ./test 
test regex
test1
test1
fail0
test1
fail0
test1
fail0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
