### PR TITLE
sdk check only if Amazon Linux

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -14,7 +14,11 @@ set(credentialsfetcher_proto_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfet
 set(credentialsfetcher_proto_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.pb.h")
 set(credentialsfetcher_grpc_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.cc")
 set(credentialsfetcher_grpc_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.h")
-find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
+
+if(${DISTRO_ID} MATCHES "amzn")
+    find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
+endif()
+
 add_custom_command(
         OUTPUT "${credentialsfetcher_proto_sources}" "${credentialsfetcher_proto_headers}" "${credentialsfetcher_grpc_sources}" "${credentialsfetcher_grpc_headers}"
         COMMAND ${_PROTOBUF_PROTOC}


### PR DESCRIPTION
*Description of changes:*
Fix sdk dependency to get added only for Amazon Linux:
1.  Added the check to only build SDK dependencies on if the distro is Amazon Linux


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
