### PR TITLE
fix protobuf detection for modern protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,16 @@ set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 set(CMAKE_SHARED_LINKER_FLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 
 set(protobuf_MODULE_COMPATIBLE TRUE)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG)
+if(NOT Protobuf_FOUND)
+    find_package(Protobuf REQUIRED)
+endif()
 find_package(gRPC REQUIRED)
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
 set(_REFLECTION gRPC::grpc++_reflection)
-find_program(_PROTOBUF_PROTOC protoc)
+if(${Protobuf_VERSION} VERSION_LESS "3.21.0.0")
+    find_program(_PROTOBUF_PROTOC protoc)
+endif()
 find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
 
 cmake_host_system_information(RESULT PRETTY_NAME QUERY DISTRIB_PRETTY_NAME)
@@ -145,15 +150,19 @@ add_custom_command(
 
 target_include_directories(credentials-fetcherd PUBLIC common)
 
+if(${Protobuf_VERSION} VERSION_GREATER_EQUAL "3.21.0.0")
+    list(APPEND _PROTOBUF_LIBPROTOBUF proto-objects)
+endif()
+
 if(${DISTRO_ID} MATCHES "ubuntu")
 	message(STATUS "Linux distro detected as ubuntu")
 target_link_libraries(credentials-fetcherd
         PUBLIC systemd krb5 glib-2.0 cf_gmsa_service_private
-        crypto protobuf kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto com_err krb5support resolv utf8_validity)
+        crypto ${_PROTOBUF_LIBPROTOBUF} kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto com_err krb5support resolv utf8_validity)
 else()
 target_link_libraries(credentials-fetcherd
         PUBLIC systemd krb5 glib-2.0 cf_gmsa_service_private
-        crypto
+        crypto ${_PROTOBUF_LIBPROTOBUF}
         kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
         com_err krb5support resolv)
 endif()

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -10,30 +10,71 @@ message(${credentialsfetcher_proto})
 set(AWSSDK_INSTALL_LIBDIR /usr/lib64)
 
 set(SERVICE_COMPONENTS s3 secretsmanager)
-set(credentialsfetcher_proto_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.pb.cc")
-set(credentialsfetcher_proto_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.pb.h")
-set(credentialsfetcher_grpc_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.cc")
-set(credentialsfetcher_grpc_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.h")
 
 if(${DISTRO_ID} MATCHES "amzn")
     find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
 endif()
 
-add_custom_command(
-        OUTPUT "${credentialsfetcher_proto_sources}" "${credentialsfetcher_proto_headers}" "${credentialsfetcher_grpc_sources}" "${credentialsfetcher_grpc_headers}"
-        COMMAND ${_PROTOBUF_PROTOC}
-        ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
-        -I "${credentialsfetcher_proto_path}"
-        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
-        "${credentialsfetcher_proto}"
-        DEPENDS "${credentialsfetcher_proto}")
+if(${Protobuf_VERSION} VERSION_LESS "3.21.0.0")
+    set(credentialsfetcher_proto_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.pb.cc")
+    set(credentialsfetcher_proto_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.pb.h")
+    set(credentialsfetcher_grpc_sources "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.cc")
+    set(credentialsfetcher_grpc_headers "${CMAKE_CURRENT_BINARY_DIR}/credentialsfetcher.grpc.pb.h")
+
+    add_custom_command(
+            OUTPUT "${credentialsfetcher_proto_sources}" "${credentialsfetcher_proto_headers}" "${credentialsfetcher_grpc_sources}" "${credentialsfetcher_grpc_headers}"
+            COMMAND ${_PROTOBUF_PROTOC}
+            ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+            -I "${credentialsfetcher_proto_path}"
+            --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+            "${credentialsfetcher_proto}"
+            DEPENDS "${credentialsfetcher_proto}")
+else()
+    add_library(proto-objects OBJECT ${credentialsfetcher_proto})
+    target_link_libraries(proto-objects PUBLIC protobuf::libprotobuf)
+    set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    target_include_directories(proto-objects PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
+    cmake_policy(SET CMP0083 NEW)
+    include(CheckPIESupported)
+    check_pie_supported()
+    if(CMAKE_CXX_LINK_PIE_SUPPORTED)
+        set_property(TARGET proto-objects
+                     PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+    else()
+        message(WARNING "PIE is not supported at link time: ${output}.\n"
+                        "PIE link options will not be passed to linker.")
+    endif()
+    protobuf_generate(
+        TARGET proto-objects
+        OUT_VAR PROTO_GENERATED_FILES
+        IMPORT_DIRS "${credentialsfetcher_proto_path}"
+        PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
+        DEPENDENCIES "${credentialsfetcher_proto}"
+    )
+    set_source_files_properties(${PROTO_GENERATED_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION on)
+    protobuf_generate(
+        TARGET proto-objects
+        OUT_VAR PROTO_GENERATED_FILES
+        LANGUAGE grpc
+        IMPORT_DIRS "${credentialsfetcher_proto_path}"
+        GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+        PLUGIN "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
+        PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
+        DEPENDENCIES "${credentialsfetcher_proto}"
+    )
+    set_source_files_properties(${PROTO_GENERATED_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION on)
+endif()
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-list(APPEND SRC_FILES ${credentialsfetcher_proto_sources})
-list(APPEND SRC_FILES ${credentialsfetcher_proto_headers})
-list(APPEND SRC_FILES ${credentialsfetcher_grpc_sources})
-list(APPEND SRC_FILES ${credentialsfetcher_grpc_headers})
+if(${Protobuf_VERSION} VERSION_LESS "3.21.0.0")
+    list(APPEND SRC_FILES ${credentialsfetcher_proto_sources})
+    list(APPEND SRC_FILES ${credentialsfetcher_proto_headers})
+    list(APPEND SRC_FILES ${credentialsfetcher_grpc_sources})
+    list(APPEND SRC_FILES ${credentialsfetcher_grpc_headers})
+else()
+    list(APPEND _PROTOBUF_LIBPROTOBUF proto-objects)
+endif()
 
 add_library(cf_gmsa_service_private OBJECT
     ${SRC_FILES}

--- a/api/tests/CMakeLists.txt
+++ b/api/tests/CMakeLists.txt
@@ -12,9 +12,13 @@ file(
         FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
 
+if (${Protobuf_VERSION} VERSION_GREATER_EQUAL "3.21.0.0")
+    list(APPEND _PROTOBUF_LIBPROTOBUF proto-objects)
+endif()
+
 add_executable(gmsa_test_client "gmsa_test_client.cpp")
 target_link_libraries(gmsa_test_client
-            cf_gmsa_service_private)
+            cf_gmsa_service_private ${_PROTOBUF_LIBPROTOBUF})
 
 cmake_policy(SET CMP0083 NEW)
 include(CheckPIESupported)


### PR DESCRIPTION
This change fixes credentials-fetcher to properly detect and use the current "modern" protobuf libraries, while also still falling back to the older protobuf in Fedora/RHEL/Amazon Linux. This work is needed for Fedora to update protobuf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
