### PR TITLE
fix: check bucket owner permission

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -2582,9 +2582,20 @@ std::string retrieve_credspec_from_s3(std::string s3_arn, std::string region, Aw
                 return dummy_credspec;
             }
 
+            // regex for callerId
+            std::regex callerIdRegex("^\\d{12}$");
+            std::string callerId = GetCallerIdentity();
+            if(callerId.empty() &&  !std::regex_match( callerId, callerIdRegex))
+            {
+                std::cout << getCurrentTime() << '\t' << "ERROR: Unable to get caller information"
+                          << std::endl;
+                return std::string("");
+            }
+
             Aws::S3::S3Client s3Client (credentials,Aws::MakeShared<Aws::S3::S3EndpointProvider>
                 (Aws::S3::S3Client::ALLOCATION_TAG), clientConfig);
             Aws::S3::Model::GetObjectRequest request;
+            request.SetExpectedBucketOwner(callerId);
             request.SetBucket(s3Bucket);
             request.SetKey(objectName);
             Aws::S3::Model::GetObjectOutcome outcome =
@@ -2667,4 +2678,5 @@ std::tuple<std::string, std::string,
     }
     return {"","",""};
 }
+
 #endif

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -1229,3 +1229,25 @@ void clearString(std::string& str) {
     // Clear the string content
     str.clear();
 }
+
+
+// get caller identity - accountId
+std::string GetCallerIdentity()
+{
+    std::string command =
+        install_path_for_aws_cli + " sts get-caller-identity --query Account";
+    // /usr/bin/aws aws sts get-caller-identity --query Account
+    std::pair<int, std::string> result = exec_shell_cmd( command );
+
+    std::string callerId = result.second;
+    ltrim( callerId );
+    rtrim( callerId );
+
+    // remove quotes if they are present
+    if ( callerId.front() == '"' ) {
+        callerId.erase( 0, 1 ); // erase the first character
+        callerId.erase( callerId.size() - 1 ); // erase the last character
+    }
+
+    return callerId;
+}

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -223,6 +223,8 @@ std::string generate_lease_id();
 
 void clearString(std::string& str);
 
+std::string GetCallerIdentity();
+
 #if AMAZON_LINUX_DISTRO
 std::string retrieve_credspec_from_s3(std::string s3_arn, std::string region, Aws::Auth::AWSCredentials credentials,  bool test);
 bool check_file_size_s3(std::string s3_arn, std::string region,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Check bucket owner permission before retrieving credentialspec
*Testing done:*
```
[ec2-user@EC2AMAZ-Ll40tS tests]$ sudo ./gmsa_test_client --create_kerberos_tickets_arn arn:aws:s3:::gmsacredspec/gmsa-cred-spec.json#3456/test xxxx xxxx xxxx us-west-2
krb tickets will get created
created ticket for gMSA /var/credentials-fetcher/krbdir/3456/test
Client received output for add kerberos arn lease: 3456
provide a valid arg, for help use -h or --help
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
