### PR TITLE
cleanup: Remove unused methods

### DIFF
--- a/common/daemon.h
+++ b/common/daemon.h
@@ -199,7 +199,6 @@ bool isValidDomain(const std::string& value);
 int HealthCheck(std::string serviceName);
 
 int parse_config_file( creds_fetcher::Daemon& cf_daemon );
-std::string retrieve_secret_from_ecs_config(std::string ecs_variable_name);
 std::vector<std::string> split_string(std::string input_string, char delimiter);
 
 /**

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -120,8 +120,6 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
                 return EXIT_FAILURE;
             }
         }
-        std::string aws_sm_secret_name = retrieve_secret_from_ecs_config(domainless_gmsa_field);
-        cf_daemon.aws_sm_secret_name = aws_sm_secret_name;
     }
     catch ( const std::exception& ex )
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove unused code block

*Testing done:*
Build ran successfully
```
make[2]: Leaving directory '/home/ec2-user/credentials-fetcher/build'
make  -f api/tests/CMakeFiles/gmsa_test_client.dir/build.make api/tests/CMakeFiles/gmsa_test_client.dir/build
make[2]: Entering directory '/home/ec2-user/credentials-fetcher/build'
make[2]: Nothing to be done for 'api/tests/CMakeFiles/gmsa_test_client.dir/build'.
make[2]: Leaving directory '/home/ec2-user/credentials-fetcher/build'
[100%] Built target gmsa_test_client
make[1]: Leaving directory '/home/ec2-user/credentials-fetcher/build'
/usr/bin/cmake -E cmake_progress_start /home/ec2-user/credentials-fetcher/build/CMakeFiles 0

```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
