### PR TITLE
Update readme file to include domainless gMSA pathway explanation within prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ For other linux distributions, the daemon binary needs to be built from source c
 
 - Active Directory server ( Windows Server )
 - Linux instances or hosts that are domain-joined to Active Directory
-  - Unless you are using Amazon Elastic Container Service - Fargate. In that case you must [use domainless gMSA](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-linux-gmsa.html#fargate-linux-gmsa-considerations).
+  - [EC2 Linux containers on Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/linux-gmsa.html#linux-gmsa-considerations) provides the option of domainless gMSA and joining each instance to a single domain
+  - [Linux containers on Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-linux-gmsa.html#fargate-linux-gmsa-considerations) must use domainless gMSA
 - gMSA account(s) in Active Directory - Follow instructions provided to create service accounts - https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts
 - Required packages as mentioned in RPM spec file.
 - Create username ec2-user or modify the systemd unit file.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can also use yum if dnf is not present.
 The daemon can be started using `sudo systemctl start credentials-fetcher`.
 
 On Enterprise Linux 9 ( RHEL | CentOS | AlmaLinux ), the binary can be installed from EPEL. To add EPEL, see the [EPEL Quickstart](_https://docs.fedoraproject.org/en-US/epel/#_quickstart_).
-Once EPEL is enabled, install credentials-fetcher with 
+Once EPEL is enabled, install credentials-fetcher with
 `sudo dnf install credentials-fetcher`.
 
 For other linux distributions, the daemon binary needs to be built from source code.
@@ -23,6 +23,7 @@ For other linux distributions, the daemon binary needs to be built from source c
 
 - Active Directory server ( Windows Server )
 - Linux instances or hosts that are domain-joined to Active Directory
+  - Unless you are using Amazon Elastic Container Service - Fargate. In that case you must [use domainless gMSA](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-linux-gmsa.html#fargate-linux-gmsa-considerations).
 - gMSA account(s) in Active Directory - Follow instructions provided to create service accounts - https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts
 - Required packages as mentioned in RPM spec file.
 - Create username ec2-user or modify the systemd unit file.
@@ -52,7 +53,9 @@ To communicate with the daemon over gRPC, install grpc-cli. For example
 `sudo yum install grpc-cli`
 
 ##### AddKerberosLease API:
+
 Note: APIs use unix domain socket
+
 ```
 Invoke the AddkerberosLease API with the credentialsspec input as shown:
 grpc_cli call {unix_domain_socket} AddKerberosLease "credspec_contents: '{credentialspec}'"
@@ -96,20 +99,19 @@ journalctl -u credentials-fetcher
 
 | Environment Key             | Examples values                    | Description                                                                                  |
 | :-------------------------- | ---------------------------------- | :------------------------------------------------------------------------------------------- |
-| `CF_KRB_DIR`                | '/var/credentials-fetcher/krbdir'  | *(Default)* Dir path for storing the kerberos tickets                                        |
-| `CF_UNIX_DOMAIN_SOCKET_DIR` | '/var/credentials-fetcher/socket'  | *(Default)* Dir path for the domain socker for gRPC communication 'credentials_fetcher.sock' |
-| `CF_LOGGING_DIR`            | '/var/credentials-fetcher/logging' | *(Default)* Dir Path for log                                                                 |
+| `CF_KRB_DIR`                | '/var/credentials-fetcher/krbdir'  | _(Default)_ Dir path for storing the kerberos tickets                                        |
+| `CF_UNIX_DOMAIN_SOCKET_DIR` | '/var/credentials-fetcher/socket'  | _(Default)_ Dir path for the domain socker for gRPC communication 'credentials_fetcher.sock' |
+| `CF_LOGGING_DIR`            | '/var/credentials-fetcher/logging' | _(Default)_ Dir Path for log                                                                 |
 | `CF_TEST_DOMAIN_NAME`       | 'contoso.com'                      | Test domain name                                                                             |
 | `CF_TEST_GMSA_ACCOUNT`      | 'webapp01'                         | Test gMSA account name                                                                       |
 
-
 #### Runtime environment variables
 
-| Environment Variable        | Examples values                          | Description                                                                                  |
-| :-------------------------- | ---------------------------------------- | :------------------------------------------------------------------------------------------- |
-| `CF_CRED_SPEC_FILE`         | '/var/credentials-fetcher/my-credspec.json' | Path to a credential spec file used as input. (Lease id default: credspec) |
-|                             | '/var/credentials-fetcher/my-credspec.json:myLeaseId' | An optional lease id specified after a colon
-| `CF_GMSA_OU`                | 'CN=Managed Service Accounts' | Component of GMSA distinguished name (see docs/cf_gmsa_ou.md) |
+| Environment Variable | Examples values                                       | Description                                                                |
+| :------------------- | ----------------------------------------------------- | :------------------------------------------------------------------------- |
+| `CF_CRED_SPEC_FILE`  | '/var/credentials-fetcher/my-credspec.json'           | Path to a credential spec file used as input. (Lease id default: credspec) |
+|                      | '/var/credentials-fetcher/my-credspec.json:myLeaseId' | An optional lease id specified after a colon                               |
+| `CF_GMSA_OU`         | 'CN=Managed Service Accounts'                         | Component of GMSA distinguished name (see docs/cf_gmsa_ou.md)              |
 
 ## Compatibility
 
@@ -127,7 +129,7 @@ Amazon Web Services does not currently provide support for modified copies of th
 
 ## Security disclosures
 
-If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+If you think you’ve found a potential security issue, please do not post it in the Issues. Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update readme file to include domainless gMSA pathway explanation within prerequisites. In order to use credential fetcher with Amazon Elastic Container Service (Amazon ECS), you must use domainless gMSA as described in the [documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-linux-gmsa.html#fargate-linux-gmsa-considerations). Looking between that documentation and the information listed in the prerequisites here, it is conflicting. This update will add the caveat for using Amazon ECS - Fargate.

*Testing done:*
N/A

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment
- [x] *No tests as this is a documentation change.*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
