### PR TITLE
build: Conditionally use dotnet-runtime-8/dotnet-sdk-8 on Fedora 41

### DIFF
--- a/auth/kerberos/src/utf16_decode/build-using-csc.sh
+++ b/auth/kerberos/src/utf16_decode/build-using-csc.sh
@@ -16,7 +16,9 @@ fi
 echo "dotnethome=$dotnethome"
 
 dotnetlib=$dotnethome/shared/Microsoft.NETCore.App/$fwkver
-if [ -d /usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/$fwkver/ref/net6.0/ ]; then
+if [ -d /usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/$fwkver/ref/net8.0/ ]; then
+   dotnetlib=/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/$fwkver/ref/net8.0/
+elif [ -d /usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/$fwkver/ref/net6.0/ ]; then
    dotnetlib=/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/$fwkver/ref/net6.0/
 fi
 echo "dotnetlib=$dotnetlib"

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -16,13 +16,22 @@ Source0:        credentials-fetcher-v.1.3.6.tar.gz
 
 BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel jsoncpp-devel
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
-BuildRequires:  systemd-rpm-macros dotnet-sdk-6.0 grpc-plugins
+BuildRequires:  systemd-rpm-macros grpc-plugins
 
 %if 0%{?amzn} >= 2023
 BuildRequires:  aws-sdk-cpp-devel aws-sdk-cpp aws-sdk-cpp-static
 %endif
- 
-Requires: bind-utils openldap openldap-clients awscli dotnet-runtime-6.0 jsoncpp
+
+# fedora41 does not support .NET6
+%if 0%{?fedora} >= 41
+BuildRequires:  dotnet-sdk-8.0
+Requires:       dotnet-runtime-8.0
+%else
+BuildRequires:  dotnet-sdk-6.0
+Requires:       dotnet-runtime-6.0
+%endif
+
+Requires: bind-utils openldap openldap-clients awscli jsoncpp
 # No one likes you i686
 ExclusiveArch: x86_64 aarch64 s390x
  


### PR DESCRIPTION
## Description of changes: ##
* https://bugzilla.redhat.com/show_bug.cgi?id=2294017
* Currently credentials-fetcher requires dotnet-runtime-6 and dotnet-sdk-6
* Fedora 41 fails to install credentials-fetcher because Fedora41 does not have .NET6 support
* To support Fedora41, use dotnet-runtime-8 and dotnet-sdk-8 if the OS is Fedora 41 or later

## Testing done: ##
Successfully built the rpm on Fedora 41 docker container, Fedora-Cloud-Base-AmazonEC2.x86_64-40 ami and al2023 ami
## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [NA ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
