### PR TITLE
    Fix: Domainless option in opensource mode

### DIFF
--- a/api/tests/gmsa_test_client.cpp
+++ b/api/tests/gmsa_test_client.cpp
@@ -835,7 +835,7 @@ int main( int argc, char** argv )
             std::cout << "krb tickets will get created" << std::endl;
             create_krb_ticket_non_domain_joined( client, credspec_contents, username, password,
                                                  domain );
-            i++;
+            return 0;
         }
         else if(arg == "--renew_kerberos_tickets_non_domain_joined" ){
             if ( i + 2 < argc )

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -252,5 +252,8 @@ int write_meta_data_json( creds_fetcher::krb_ticket_info* krb_ticket_info,
 int write_meta_data_json( std::list<creds_fetcher::krb_ticket_info*> krb_ticket_info_list,
                           std::string lease_id, std::string krb_files_dir );
 
+bool set_ecs_mode(bool);
+bool is_ecs_mode();
+
 
 #endif // _daemon_h_

--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -120,8 +120,11 @@ int parse_options( int argc, const char* argv[], creds_fetcher::Daemon& cf_daemo
                 return EXIT_FAILURE;
             }
         }
-        std::string aws_sm_secret_name = retrieve_secret_from_ecs_config(domainless_gmsa_field);
-        cf_daemon.aws_sm_secret_name = aws_sm_secret_name;
+
+        if ( cf_daemon.aws_sm_secret_name.empty() ) {
+            cf_daemon.aws_sm_secret_name = retrieve_secret_from_ecs_config(domainless_gmsa_field);
+            set_ecs_mode(true);
+        }
     }
     catch ( const std::exception& ex )
     {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/credentials-fetcher/discussions/129

*Description of changes:*
    The domainless option in ecs mode was overwriting the previously existing opensource mode

*Testing done:*
Testing:
    $ ./credentials-fetcherd  --aws_sm_secret_name  aws/directoryservices/d-xxxxxxxxx:/gmsa &
     $ ./api/tests/gmsa_test_client --create_kerberos_tickets_non_domain_joined "user1" "xxx" "CONTOSO.COM"
      krb tickets will get created
    created ticket file /var/credentials-fetcher/krbdir/1377bbf83874d1a8b7bb/WebApp01
    created ticket file /var/credentials-fetcher/krbdir/1377bbf83874d1a8b7bb/WebApp03
    Client received output for add kerberos lease non domain joined: 1377bbf83874d1a8b7bb

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X ] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [ X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [ X] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [X ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
