### PR TITLE
fix: variadic methods build errors

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -1243,7 +1243,7 @@ class CredentialsFetcherImpl final
                         }
                         else
                         {
-                            log_message = "gMSA ticket is at " + gmsa_ticket_result.second.c_str();
+                            log_message = "gMSA ticket is at " + gmsa_ticket_result.second;
                             cf_logger.logger( LOG_INFO, log_message.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t'
                                       << "INFO: gMSA ticket is at " << gmsa_ticket_result.second

--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -617,7 +617,8 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR :" + std::to_string( status.first ) +
                                       ": Cannot retrieve domainless user kerberos tickets";
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(), status );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
+                                              std::to_string( status.first ).c_str() );
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
                         }
@@ -644,7 +645,8 @@ class CredentialsFetcherImpl final
                                       ": Cannot get gMSA krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg.c_str()
                                       << std::endl;
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(), status.first );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
+                                              std::to_string( status.first ).c_str() );
                             break;
                         }
                         else
@@ -1198,7 +1200,7 @@ class CredentialsFetcherImpl final
                         if ( status.first < 0 )
                         {
                             cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                                              status );
+                                              std::to_string( status.first ).c_str() );
                             err_msg = "ERROR: cannot get machine krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
@@ -1233,7 +1235,7 @@ class CredentialsFetcherImpl final
                             err_msg = "ERROR: Cannot get gMSA krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
-                                              status );
+                                              std::to_string( status.first ).c_str() );
                             break;
                         }
                         else
@@ -1516,7 +1518,8 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR: " + std::to_string( status.first ) +
                                       ": cannot retrieve domainless user kerberos tickets";
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(), status.first );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
+                                              std::to_string( status.first ).c_str() );
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
                         }
@@ -1564,7 +1567,8 @@ class CredentialsFetcherImpl final
                             err_msg =
                                 "ERROR: Cannot get gMSA krb ticket " + gmsa_ticket_result.second;
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(), gmsa_ticket_result.second );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
+                                              gmsa_ticket_result.second.c_str() );
                             break;
                         }
                         else
@@ -2438,7 +2442,8 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         status = generate_krb_ticket_from_machine_keytab( krb_ticket_info->domain_name, cf_logger );
         if ( status.first < 0 )
         {
-            cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket", status );
+            cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket",
+                              std::to_string( status.first ).c_str() );
             delete krb_ticket_info;
 
             return EXIT_FAILURE;
@@ -2448,7 +2453,7 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         if ( std::filesystem::exists( krb_file_path ) )
         {
             cf_logger.logger( LOG_INFO, "Deleting existing credential file directory %s",
-                              +krb_file_path.c_str() );
+                              krb_file_path.c_str() );
 
             std::filesystem::remove_all( krb_file_path );
         }
@@ -2470,7 +2475,8 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         {
             err_msg = "ERROR: Cannot get gMSA krb ticket";
             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-            cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket", status );
+            cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
+                              std::to_string( status.first ).c_str() );
         }
         else
         {

--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -617,8 +617,9 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR :" + std::to_string( status.first ) +
                                       ": Cannot retrieve domainless user kerberos tickets";
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
-                                              std::to_string( status.first ).c_str() );
+                            cf_logger.logger(
+                                LOG_ERR, err_msg.c_str(),
+                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
                         }
@@ -1199,8 +1200,9 @@ class CredentialsFetcherImpl final
                         }
                         if ( status.first < 0 )
                         {
-                            cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                                              std::to_string( status.first ).c_str() );
+                            cf_logger.logger(
+                                LOG_ERR, "Error %d: Cannot get machine krb ticket",
+                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
                             err_msg = "ERROR: cannot get machine krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
@@ -1234,8 +1236,9 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR: Cannot get gMSA krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-                            cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
-                                              std::to_string( status.first ).c_str() );
+                            cf_logger.logger(
+                                LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
+                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
                             break;
                         }
                         else
@@ -2443,7 +2446,7 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         if ( status.first < 0 )
         {
             cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                              std::to_string( status.first ).c_str() );
+                              ( std::to_string( status.first ) + " " + status.second ).c_str() );
             delete krb_ticket_info;
 
             return EXIT_FAILURE;
@@ -2476,7 +2479,7 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
             err_msg = "ERROR: Cannot get gMSA krb ticket";
             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
             cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
-                              std::to_string( status.first ).c_str() );
+                              ( std::to_string( status.first ) + " " + status.second ).c_str() );
         }
         else
         {

--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -603,10 +603,9 @@ class CredentialsFetcherImpl final
                         std::pair<int, std::string> status;
                         if ( username.empty() || password.empty() )
                         {
-                            cf_logger.logger( LOG_ERR,
-                                              "Invalid credentials for "
-                                              "domainless user ",
-                                              username.c_str() );
+                            std::string log_message =
+                                "Invalid credentials for domainless user " + username;
+                            cf_logger.logger( LOG_ERR, log_message.c_str() );
                             err_msg = "ERROR: Invalid credentials for domainless user";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
@@ -617,9 +616,10 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR :" + std::to_string( status.first ) +
                                       ": Cannot retrieve domainless user kerberos tickets";
-                            cf_logger.logger(
-                                LOG_ERR, err_msg.c_str(),
-                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
+                            std::string log_message = err_msg +
+                                                      " Status: " + std::to_string( status.first ) +
+                                                      " " + status.second;
+                            cf_logger.logger( LOG_ERR, log_message.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
                         }
@@ -646,14 +646,14 @@ class CredentialsFetcherImpl final
                                       ": Cannot get gMSA krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg.c_str()
                                       << std::endl;
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
-                                              std::to_string( status.first ).c_str() );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str() );
                             break;
                         }
                         else
                         {
-                            cf_logger.logger( LOG_INFO, "gMSA ticket is at %s",
-                                              gmsa_ticket_result.second.c_str() );
+                            std::string log_message =
+                                "gMSA ticket is at " + gmsa_ticket_result.second;
+                            cf_logger.logger( LOG_INFO, log_message.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t'
                                       << "INFO: gMSA ticket is "
                                          "created"
@@ -1143,6 +1143,7 @@ class CredentialsFetcherImpl final
                 std::unordered_set<std::string> krb_ticket_dirs;
 
                 std::string err_msg;
+                std::string log_message;
                 create_krb_reply_.set_lease_id( lease_id );
                 for ( int i = 0; i < create_krb_request_.credspec_contents_size(); i++ )
                 {
@@ -1200,9 +1201,9 @@ class CredentialsFetcherImpl final
                         }
                         if ( status.first < 0 )
                         {
-                            cf_logger.logger(
-                                LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
+                            log_message = "Error: " + std::to_string( status.first ) +
+                                          " Cannot get machine krb ticket " + status.second;
+                            cf_logger.logger( LOG_ERR, log_message.c_str() );
                             err_msg = "ERROR: cannot get machine krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
@@ -1211,10 +1212,9 @@ class CredentialsFetcherImpl final
                         std::string krb_file_path = krb_ticket->krb_file_path;
                         if ( std::filesystem::exists( krb_file_path ) )
                         {
-                            cf_logger.logger( LOG_INFO,
-                                              "Directory already exists: "
-                                              "%s",
-                                              krb_file_path.c_str() );
+                            log_message = "Directory already exists: " + krb_file_path;
+
+                            cf_logger.logger( LOG_INFO, log_message.c_str() );
                             break;
                         }
                         std::filesystem::create_directories( krb_file_path );
@@ -1236,15 +1236,15 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR: Cannot get gMSA krb ticket";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-                            cf_logger.logger(
-                                LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
-                                ( std::to_string( status.first ) + " " + status.second ).c_str() );
+                            log_message = "ERROR: Cannot get gMSA krb ticket " +
+                                          std::to_string( status.first ) + " " + status.second;
+                            cf_logger.logger( LOG_ERR, log_message.c_str() );
                             break;
                         }
                         else
                         {
-                            cf_logger.logger( LOG_INFO, "gMSA ticket is at %s",
-                                              gmsa_ticket_result.second.c_str() );
+                            log_message = "gMSA ticket is at " + gmsa_ticket_result.second.c_str();
+                            cf_logger.logger( LOG_INFO, log_message.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t'
                                       << "INFO: gMSA ticket is at " << gmsa_ticket_result.second
                                       << std::endl;
@@ -1427,6 +1427,7 @@ class CredentialsFetcherImpl final
                 std::string domain = create_domainless_krb_request_.domain();
 
                 std::string err_msg;
+                std::string log_message;
                 if ( isValidDomain( domain ) &&
                      !contains_invalid_characters_in_ad_account_name( username ) )
                 {
@@ -1507,10 +1508,8 @@ class CredentialsFetcherImpl final
                         std::pair<int, std::string> status;
                         if ( username.empty() || password.empty() )
                         {
-                            cf_logger.logger( LOG_ERR,
-                                              "Invalid credentials for "
-                                              "domainless user ",
-                                              username.c_str() );
+                            log_message = "Invalid credentials for domainless user " + username;
+                            cf_logger.logger( LOG_ERR, log_message.c_str() );
                             err_msg = "ERROR: Invalid credentials for domainless user";
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
@@ -1521,8 +1520,7 @@ class CredentialsFetcherImpl final
                         {
                             err_msg = "ERROR: " + std::to_string( status.first ) +
                                       ": cannot retrieve domainless user kerberos tickets";
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
-                                              std::to_string( status.first ).c_str() );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                             break;
                         }
@@ -1530,10 +1528,8 @@ class CredentialsFetcherImpl final
                         std::string krb_file_path = krb_ticket->krb_file_path;
                         if ( std::filesystem::exists( krb_file_path ) )
                         {
-                            cf_logger.logger( LOG_INFO,
-                                              "Directory already exists: "
-                                              "%s",
-                                              krb_file_path.c_str() );
+                            log_message = "Directory already exists: " + krb_file_path;
+                            cf_logger.logger( LOG_INFO, log_message.c_str() );
                             break;
                         }
                         std::filesystem::create_directories( krb_file_path );
@@ -1570,14 +1566,13 @@ class CredentialsFetcherImpl final
                             err_msg =
                                 "ERROR: Cannot get gMSA krb ticket " + gmsa_ticket_result.second;
                             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-                            cf_logger.logger( LOG_ERR, err_msg.c_str(),
-                                              gmsa_ticket_result.second.c_str() );
+                            cf_logger.logger( LOG_ERR, err_msg.c_str() );
                             break;
                         }
                         else
                         {
-                            cf_logger.logger( LOG_INFO, "gMSA ticket is at %s",
-                                              gmsa_ticket_result.second.c_str() );
+                            log_message = "gMSA ticket is at " + gmsa_ticket_result.second;
+                            cf_logger.logger( LOG_INFO, log_message.c_str() );
                             std::cerr << Util::getCurrentTime() << '\t'
                                       << "INFO: gMSA ticket is created" << std::endl;
                         }
@@ -2390,15 +2385,16 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
 {
     std::string err_msg;
     std::string credspec_contents;
+    std::string log_message = "Generating lease id " + cred_file_lease_id;
 
-    cf_logger.logger( LOG_INFO, "Generating lease id %s", cred_file_lease_id.c_str() );
+    cf_logger.logger( LOG_INFO, log_message.c_str() );
 
     if ( !std::filesystem::exists( credspec_filepath ) )
     {
         std::cerr << Util::getCurrentTime() << '\t' << "The credential spec file "
                   << credspec_filepath << " was not found!" << std::endl;
-        cf_logger.logger( LOG_ERR, "The credential spec file %s was not found!",
-                          credspec_filepath.c_str() );
+        log_message = "The credential spec file " + credspec_filepath + " was not found!";
+        cf_logger.logger( LOG_ERR, log_message.c_str() );
         return EXIT_FAILURE;
     }
 
@@ -2412,8 +2408,8 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
     }
     else
     {
-        cf_logger.logger( LOG_ERR, "Unable to open credential spec file: %s",
-                          credspec_filepath.c_str() );
+        log_message = "Unable to open credential spec file: " + credspec_filepath;
+        cf_logger.logger( LOG_ERR, log_message.c_str() );
         std::cerr << Util::getCurrentTime() << '\t'
                   << "Unable to open credential spec file: " << credspec_filepath << std::endl;
 
@@ -2445,8 +2441,9 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         status = generate_krb_ticket_from_machine_keytab( krb_ticket_info->domain_name, cf_logger );
         if ( status.first < 0 )
         {
-            cf_logger.logger( LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                              ( std::to_string( status.first ) + " " + status.second ).c_str() );
+            log_message = "Error: " + std::to_string( status.first ) + " " + status.second +
+                          " Cannot get machine krb ticket";
+            cf_logger.logger( LOG_ERR, log_message.c_str() );
             delete krb_ticket_info;
 
             return EXIT_FAILURE;
@@ -2455,8 +2452,8 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         std::string krb_file_path = krb_ticket_info->krb_file_path;
         if ( std::filesystem::exists( krb_file_path ) )
         {
-            cf_logger.logger( LOG_INFO, "Deleting existing credential file directory %s",
-                              krb_file_path.c_str() );
+            log_message = "Deleting existing credential file directory " + krb_file_path;
+            cf_logger.logger( LOG_INFO, log_message.c_str() );
 
             std::filesystem::remove_all( krb_file_path );
         }
@@ -2478,14 +2475,15 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         {
             err_msg = "ERROR: Cannot get gMSA krb ticket";
             std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
-            cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket",
-                              ( std::to_string( status.first ) + " " + status.second ).c_str() );
+            log_message = "ERROR: Cannot get gMSA krb ticket " + std::to_string( status.first ) +
+                          " " + status.second;
+            cf_logger.logger( LOG_ERR, log_message.c_str() );
         }
         else
         {
             chmod( krb_ccname_str.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
-
-            cf_logger.logger( LOG_INFO, "gMSA ticket is at %s", gmsa_ticket_result.second.c_str() );
+            log_message = "gMSA ticket is at " + gmsa_ticket_result.second;
+            cf_logger.logger( LOG_INFO, log_message.c_str() );
             std::cerr << Util::getCurrentTime() << '\t' << "INFO: gMSA ticket is created"
                       << std::endl;
         }
@@ -2500,7 +2498,7 @@ int ProcessCredSpecFile( std::string krb_files_dir, std::string credspec_filepat
         std::filesystem::remove_all( krb_ticket_info->krb_file_path );
 
         std::cerr << err_msg << std::endl;
-        cf_logger.logger( LOG_ERR, "%s", err_msg.c_str() );
+        cf_logger.logger( LOG_ERR, err_msg.c_str() );
         delete krb_ticket_info;
 
         return EXIT_FAILURE;

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -30,42 +30,42 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
     result = Util::is_hostname_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
     result = Util::is_hostname_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
     result = Util::is_realm_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
     result = Util::is_kinit_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
     result = Util::is_ldapsearch_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
     result = Util::is_decode_exe_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
@@ -79,7 +79,7 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
         std::cerr << "ERROR: " << __func__ << ":" << __LINE__ << " invalid machine principal"
                   << std::endl;
         std::string err_msg = "ERROR: invalid machine principal";
-        cf_logger.logger( LOG_ERR, err_msg.c_str() );
+        cf_logger.logger( LOG_ERR, err_msg.c_str(), "" );
         result = std::make_pair( -1, err_msg );
         return result;
     }
@@ -87,7 +87,7 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
     result = Util::execute_kinit_in_domain_joined_case( machine_principal.second );
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
         return result;
     }
 
@@ -121,7 +121,9 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
 
     if ( domain_name.empty() || gmsa_account_name.empty() )
     {
-        cf_logger.logger( LOG_ERR, "ERROR: %s:%d null args", __func__, __LINE__ );
+        cf_logger.logger(
+            LOG_ERR, "ERROR: %s:%d null args",
+            ( std::string( __func__ ) + " : " + std::to_string( __LINE__ ) ).c_str() );
         std::string err_msg = std::string( "domain_name " + domain_name + " or gmsa_account_name " +
                                            gmsa_account_name + " is empty" );
         return std::make_pair( -1, err_msg );
@@ -153,7 +155,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
                 distinguished_name = distinguished_name_result.second;
             }
             std::string log_str = "Found dn = " + distinguished_name + "\n";
-            cf_logger.logger( LOG_INFO, log_str.c_str() );
+            cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
         }
 
         krb_ticket->distinguished_name = distinguished_name;
@@ -171,7 +173,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
                 log_str = "ldapsearch successful with FQDN = " + fqdn + ", cmd = " + log_str + "," +
                           "search_string = " + search_string + "\n";
                 std::cerr << log_str << std::endl;
-                cf_logger.logger( LOG_INFO, log_str.c_str() );
+                cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
             }
             break;
         }
@@ -180,7 +182,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
             std::string log_str = "ldapsearch failed with FQDN = " + fqdn + " " +
                                   ldap_search_result.second.c_str() + " " + search_string;
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_INFO, log_str.c_str() );
+            cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
         }
     }
     fqdn_list_result.clear();
@@ -199,7 +201,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
     {
         std::string log_str = Util::getCurrentTime() + '\t' + "ERROR: Password not found";
         std::cerr << log_str << std::endl;
-        cf_logger.logger( LOG_ERR, log_str.c_str() );
+        cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
         return std::make_pair( -1, log_str );
     }
 
@@ -221,7 +223,8 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
         perror( "kinit failed" );
         OPENSSL_cleanse( password_found_result.second, password_found_result.first );
         OPENSSL_free( password_found_result.second );
-        cf_logger.logger( LOG_ERR, "ERROR: %s:%d kinit failed", __func__, __LINE__ );
+        cf_logger.logger( LOG_ERR, "ERROR: %s:%d kinit failed",
+                          ( std::string( __func__ ) + ":" + std::to_string( __LINE__ ) ).c_str() );
         std::cerr << Util::getCurrentTime() << '\t' << "ERROR: kinit failed" << std::endl;
         return std::make_pair( -1, std::string( "kinit failed" ) );
     }
@@ -232,7 +235,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
     std::string log_str = Util::getCurrentTime() + '\t' +
                           "INFO: kinit return value = " + std::to_string( error_code );
     std::cerr << log_str << std::endl;
-    cf_logger.logger( LOG_ERR, log_str.c_str() );
+    cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
 
     OPENSSL_cleanse( password_found_result.second, password_found_result.first );
 
@@ -293,7 +296,7 @@ std::string get_ticket_expiration( std::string klist_ticket_info, CF_logger& cf_
             std::string log_str =
                 "Unable to parse klist for ticket expiration: " + klist_ticket_info;
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_ERR, log_str.c_str() );
+            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
             return std::string( "" );
         }
     }
@@ -339,7 +342,7 @@ std::string get_ticket_expiration( std::string klist_ticket_info, CF_logger& cf_
 
     std::string log_str = "klist expires date = " + klist_expires_date + " " + klist_expires_time;
     std::cerr << log_str << std::endl;
-    cf_logger.logger( LOG_INFO, log_str.c_str() );
+    cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
     return klist_expires_date + " " + klist_expires_time;
 }
 
@@ -534,7 +537,8 @@ std::string renew_gmsa_ticket( krb_ticket_info_t* krb_ticket, std::string domain
 
                 if ( status.first < 0 )
                 {
-                    cf_logger.logger( LOG_ERR, "ERROR %d: Cannot get user krb ticket", status );
+                    cf_logger.logger( LOG_ERR, "ERROR %d: Cannot get user krb ticket",
+                                      std::to_string( status.first ).c_str() );
                     std::cerr << Util::getCurrentTime() << '\t'
                               << "ERROR: Cannot get user krb ticket" << std::endl;
                 }

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -65,7 +65,8 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
     result = Util::is_decode_exe_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str() ) return result;
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
+        return result;
     }
 
     /**

--- a/auth/kerberos/src/krb.cpp
+++ b/auth/kerberos/src/krb.cpp
@@ -30,43 +30,42 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
     result = Util::is_hostname_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
     result = Util::is_hostname_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
     result = Util::is_realm_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
     result = Util::is_kinit_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
     result = Util::is_ldapsearch_cmd_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
     result = Util::is_decode_exe_present();
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
-        return result;
+        cf_logger.logger( LOG_ERR, result.second.c_str() ) return result;
     }
 
     /**
@@ -79,7 +78,7 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
         std::cerr << "ERROR: " << __func__ << ":" << __LINE__ << " invalid machine principal"
                   << std::endl;
         std::string err_msg = "ERROR: invalid machine principal";
-        cf_logger.logger( LOG_ERR, err_msg.c_str(), "" );
+        cf_logger.logger( LOG_ERR, err_msg.c_str() );
         result = std::make_pair( -1, err_msg );
         return result;
     }
@@ -87,7 +86,7 @@ std::pair<int, std::string> generate_krb_ticket_from_machine_keytab( std::string
     result = Util::execute_kinit_in_domain_joined_case( machine_principal.second );
     if ( result.first != 0 )
     {
-        cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+        cf_logger.logger( LOG_ERR, result.second.c_str() );
         return result;
     }
 
@@ -121,9 +120,9 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
 
     if ( domain_name.empty() || gmsa_account_name.empty() )
     {
-        cf_logger.logger(
-            LOG_ERR, "ERROR: %s:%d null args",
-            ( std::string( __func__ ) + " : " + std::to_string( __LINE__ ) ).c_str() );
+        std::string log_message =
+            "ERROR: " + std::string( __func__ ) + ": " + std::to_string( __LINE__ ) + " null args";
+        cf_logger.logger( LOG_ERR, log_message.c_str() );
         std::string err_msg = std::string( "domain_name " + domain_name + " or gmsa_account_name " +
                                            gmsa_account_name + " is empty" );
         return std::make_pair( -1, err_msg );
@@ -154,8 +153,8 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
             {
                 distinguished_name = distinguished_name_result.second;
             }
-            std::string log_str = "Found dn = " + distinguished_name + "\n";
-            cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
+            std::string log_str = "Found dn = " + distinguished_name;
+            cf_logger.logger( LOG_INFO, log_str.c_str() );
         }
 
         krb_ticket->distinguished_name = distinguished_name;
@@ -171,9 +170,9 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
             {
                 std::string log_str = ldap_search_result.second.substr( 0, pos );
                 log_str = "ldapsearch successful with FQDN = " + fqdn + ", cmd = " + log_str + "," +
-                          "search_string = " + search_string + "\n";
+                          "search_string = " + search_string;
                 std::cerr << log_str << std::endl;
-                cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
+                cf_logger.logger( LOG_INFO, log_str.c_str() );
             }
             break;
         }
@@ -182,7 +181,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
             std::string log_str = "ldapsearch failed with FQDN = " + fqdn + " " +
                                   ldap_search_result.second.c_str() + " " + search_string;
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
+            cf_logger.logger( LOG_INFO, log_str.c_str() );
         }
     }
     fqdn_list_result.clear();
@@ -201,7 +200,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
     {
         std::string log_str = Util::getCurrentTime() + '\t' + "ERROR: Password not found";
         std::cerr << log_str << std::endl;
-        cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
+        cf_logger.logger( LOG_ERR, log_str.c_str() );
         return std::make_pair( -1, log_str );
     }
 
@@ -223,8 +222,9 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
         perror( "kinit failed" );
         OPENSSL_cleanse( password_found_result.second, password_found_result.first );
         OPENSSL_free( password_found_result.second );
-        cf_logger.logger( LOG_ERR, "ERROR: %s:%d kinit failed",
-                          ( std::string( __func__ ) + ":" + std::to_string( __LINE__ ) ).c_str() );
+        std::string log_message = "ERROR: " + std::string( __func__ ) + " : " +
+                                  std::to_string( __LINE__ ) + " kinit failed";
+        cf_logger.logger( LOG_ERR, log_message.c_str() );
         std::cerr << Util::getCurrentTime() << '\t' << "ERROR: kinit failed" << std::endl;
         return std::make_pair( -1, std::string( "kinit failed" ) );
     }
@@ -235,7 +235,7 @@ std::pair<int, std::string> fetch_gmsa_password_and_create_krb_ticket(
     std::string log_str = Util::getCurrentTime() + '\t' +
                           "INFO: kinit return value = " + std::to_string( error_code );
     std::cerr << log_str << std::endl;
-    cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
+    cf_logger.logger( LOG_ERR, log_str.c_str() );
 
     OPENSSL_cleanse( password_found_result.second, password_found_result.first );
 
@@ -296,7 +296,7 @@ std::string get_ticket_expiration( std::string klist_ticket_info, CF_logger& cf_
             std::string log_str =
                 "Unable to parse klist for ticket expiration: " + klist_ticket_info;
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
+            cf_logger.logger( LOG_ERR, log_str.c_str() );
             return std::string( "" );
         }
     }
@@ -342,7 +342,7 @@ std::string get_ticket_expiration( std::string klist_ticket_info, CF_logger& cf_
 
     std::string log_str = "klist expires date = " + klist_expires_date + " " + klist_expires_time;
     std::cerr << log_str << std::endl;
-    cf_logger.logger( LOG_INFO, log_str.c_str(), "" );
+    cf_logger.logger( LOG_INFO, log_str.c_str() );
     return klist_expires_date + " " + klist_expires_time;
 }
 
@@ -500,7 +500,7 @@ std::string renew_gmsa_ticket( krb_ticket_info_t* krb_ticket, std::string domain
     std::string renewed_krb_ticket_path;
     std::pair<int, std::string> gmsa_ticket_result;
     std::string krb_cc_name = krb_ticket->krb_file_path;
-
+    std::string log_message;
     // gMSA kerberos ticket generation needs to have ldap over kerberos
     // if the ticket exists for the machine/user already reuse it for getting gMSA password else
     // retry the ticket creation again after generating user/machine kerberos ticket
@@ -513,16 +513,16 @@ std::string renew_gmsa_ticket( krb_ticket_info_t* krb_ticket, std::string domain
         {
             if ( i == 0 )
             {
-                cf_logger.logger( LOG_WARNING,
-                                  "WARNING: Cannot get gMSA krb ticket "
-                                  "because of expired user/machine ticket, "
-                                  "will be retried automatically, service_account_name = %s",
-                                  krb_ticket->service_account_name.c_str() );
+                log_message = "WARNING: Cannot get gMSA krb ticket because of expired user/machine "
+                              "ticket, will be retried automatically, service_account_name = " +
+                              krb_ticket->service_account_name;
+                cf_logger.logger( LOG_WARNING, log_message.c_str() );
             }
             else
             {
-                cf_logger.logger( LOG_ERR, "ERROR: Cannot get gMSA krb ticket using account %s",
-                                  krb_ticket->service_account_name.c_str() );
+                log_message = "ERROR: Cannot get gMSA krb ticket using account " +
+                              krb_ticket->service_account_name;
+                cf_logger.logger( LOG_ERR, log_message.c_str() );
 
                 std::cerr << Util::getCurrentTime() << '\t'
                           << "ERROR: Cannot get gMSA krb ticket using account" << std::endl;
@@ -537,8 +537,9 @@ std::string renew_gmsa_ticket( krb_ticket_info_t* krb_ticket, std::string domain
 
                 if ( status.first < 0 )
                 {
-                    cf_logger.logger( LOG_ERR, "ERROR %d: Cannot get user krb ticket",
-                                      std::to_string( status.first ).c_str() );
+                    log_message =
+                        "ERROR " + std::to_string( status.first ) + ": Cannot get user krb ticket";
+                    cf_logger.logger( LOG_ERR, log_message.c_str() );
                     std::cerr << Util::getCurrentTime() << '\t'
                               << "ERROR: Cannot get user krb ticket" << std::endl;
                 }

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -135,7 +135,7 @@ class CF_logger
         {
             std::string logFmt = fmt;
             std::replace( logFmt.begin(), logFmt.end(), '\n', ' ' );
-            sd_journal_print( level, logFmt.c_str() );
+            sd_journal_print( level, logFmt.c_str(), logs );
             write_log( logFmt.c_str(), logs );
         }
     }

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -89,15 +89,10 @@ class CF_logger
         log_level = _log_level;
     }
 
-    void write_log( const char* format, ... )
+    void write_log( const char* format, const char* message )
     {
-        const int max_log_len = 10 * 1024 * 1024; // 10 MB
 
-        char buffer[256];
-        va_list args;
-        va_start( args, format );
-        vsnprintf( buffer, 255, format, args );
-        va_end( args );
+        const int max_log_len = 10 * 1024 * 1024; // 10 MB
 
         int fd = open( "/var/credentials-fetcher/logging/credentials-fetcher.log", O_RDWR );
         struct stat st;
@@ -124,30 +119,24 @@ class CF_logger
             char time_buffer[80];
             strftime( time_buffer, 80, "%Y-%m-%d %H:%M:%S", local_time );
             fprintf( fp, "%s: ", time_buffer );
-            fprintf( fp, format, buffer );
+            fprintf( fp, format, message );
             fprintf( fp, "\n" );
             fclose( fp );
         }
-        std::string log_buf = std::string( buffer, strlen( buffer ) );
+        std::string log_buf = std::string( message );
         log_ring_buffer[log_buffer_count] = log_buf;
         log_buffer_count = ( log_buffer_count + 1 ) % MAX_LOG_BUFFER_COUNT;
         close( fd );
     }
 
-    template <typename... Logs> void logger( const int level, const char* fmt, Logs... logs )
+    void logger( const int level, const char* fmt, const char* logs )
     {
         if ( level >= log_level )
         {
             std::string logFmt = fmt;
-            for ( int i = 0; logFmt[i] != '\0'; ++i )
-            {
-                if ( logFmt[i] == '\n' )
-                {
-                    logFmt[i] = ' '; // Replace '\n' with space
-                }
-            }
-            sd_journal_print( level, logFmt.c_str(), logs... );
-            write_log( logFmt.c_str(), logs... );
+            std::replace( logFmt.begin(), logFmt.end(), '\n', ' ' );
+            sd_journal_print( level, logFmt.c_str() );
+            write_log( logFmt.c_str(), logs );
         }
     }
 };

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -91,8 +91,6 @@ class CF_logger
 
     void write_log( const char* message )
     {
-
-        printf("format string: %s", format);
         const int max_log_len = 10 * 1024 * 1024; // 10 MB
 
         int fd = open( "/var/credentials-fetcher/logging/credentials-fetcher.log", O_RDWR );

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -89,9 +89,10 @@ class CF_logger
         log_level = _log_level;
     }
 
-    void write_log( const char* format, const char* message )
+    void write_log( const char* message )
     {
 
+        printf("format string: %s", format);
         const int max_log_len = 10 * 1024 * 1024; // 10 MB
 
         int fd = open( "/var/credentials-fetcher/logging/credentials-fetcher.log", O_RDWR );
@@ -118,9 +119,7 @@ class CF_logger
             struct tm* local_time = localtime( &current_time );
             char time_buffer[80];
             strftime( time_buffer, 80, "%Y-%m-%d %H:%M:%S", local_time );
-            fprintf( fp, "%s: ", time_buffer );
-            fprintf( fp, format, message );
-            fprintf( fp, "\n" );
+            fprintf( fp, "%s: %s \n", time_buffer, message );
             fclose( fp );
         }
         std::string log_buf = std::string( message );
@@ -129,14 +128,14 @@ class CF_logger
         close( fd );
     }
 
-    void logger( const int level, const char* fmt, const char* logs )
+    void logger( const int level, const char* logs )
     {
         if ( level >= log_level )
         {
-            std::string logFmt = fmt;
-            std::replace( logFmt.begin(), logFmt.end(), '\n', ' ' );
-            sd_journal_print( level, logFmt.c_str(), logs );
-            write_log( logFmt.c_str(), logs );
+            // std::string logFmt = fmt;
+            // std::replace( logFmt.begin(), logFmt.end(), '\n', ' ' );
+            sd_journal_print( level, "%s", logs );
+            write_log( logs );
         }
     }
 };

--- a/common/util.hpp
+++ b/common/util.hpp
@@ -845,7 +845,7 @@ class Util
         {
             std::string err_msg = "[Optional] DN from Secrets Manager = " + distinguished_name;
             std::cerr << err_msg << std::endl;
-            cf_logger.logger( LOG_ERR, err_msg.c_str(), "" );
+            cf_logger.logger( LOG_ERR, err_msg.c_str() );
         }
 
         std::transform( domain_name.begin(), domain_name.end(), domain_name.begin(),
@@ -893,14 +893,14 @@ class Util
         result = Util::is_kinit_cmd_present();
         if ( result.first != 0 )
         {
-            cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+            cf_logger.logger( LOG_ERR, result.second.c_str() );
             return result;
         }
 
         result = Util::is_ldapsearch_cmd_present();
         if ( result.first != 0 )
         {
-            cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
+            cf_logger.logger( LOG_ERR, result.second.c_str() );
             return result;
         }
 
@@ -960,12 +960,11 @@ class Util
         // truncate the hostname to the host name size limit defined by microsoft
         if ( host_name.length() > HOST_NAME_LENGTH_LIMIT )
         {
-            cf_logger.logger(
-                LOG_ERR,
-                "WARNING: %s:%d hostname exceeds 15 characters,"
-                "this can cause problems in getting kerberos tickets, please reduce "
-                "hostname length",
-                ( std::string( __func__ ) + " : " + std::to_string( __LINE__ ) ).c_str() );
+            std::string log_message = "WARNING: " + std::string( __func__ ) + " : " +
+                                      std::to_string( __LINE__ ) +
+                                      " hostname exceeds 15 characters, this can cause problems in "
+                                      "getting kerberos tickets, please reduce hostname length";
+            cf_logger.logger( LOG_ERR, log_message.c_str() );
             host_name = host_name.substr( 0, HOST_NAME_LENGTH_LIMIT );
             std::cerr << Util::getCurrentTime() << '\t'
                       << "INFO: hostname exceeds 15 characters this can "

--- a/common/util.hpp
+++ b/common/util.hpp
@@ -845,7 +845,7 @@ class Util
         {
             std::string err_msg = "[Optional] DN from Secrets Manager = " + distinguished_name;
             std::cerr << err_msg << std::endl;
-            cf_logger.logger( LOG_ERR, err_msg.c_str() );
+            cf_logger.logger( LOG_ERR, err_msg.c_str(), "" );
         }
 
         std::transform( domain_name.begin(), domain_name.end(), domain_name.begin(),
@@ -893,14 +893,14 @@ class Util
         result = Util::is_kinit_cmd_present();
         if ( result.first != 0 )
         {
-            cf_logger.logger( LOG_ERR, result.second.c_str() );
+            cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
             return result;
         }
 
         result = Util::is_ldapsearch_cmd_present();
         if ( result.first != 0 )
         {
-            cf_logger.logger( LOG_ERR, result.second.c_str() );
+            cf_logger.logger( LOG_ERR, result.second.c_str(), "" );
             return result;
         }
 
@@ -960,11 +960,12 @@ class Util
         // truncate the hostname to the host name size limit defined by microsoft
         if ( host_name.length() > HOST_NAME_LENGTH_LIMIT )
         {
-            cf_logger.logger( LOG_ERR,
-                              "WARNING: %s:%d hostname exceeds 15 characters,"
-                              "this can cause problems in getting kerberos tickets, please reduce "
-                              "hostname length",
-                              __func__, __LINE__ );
+            cf_logger.logger(
+                LOG_ERR,
+                "WARNING: %s:%d hostname exceeds 15 characters,"
+                "this can cause problems in getting kerberos tickets, please reduce "
+                "hostname length",
+                ( std::string( __func__ ) + " : " + std::to_string( __LINE__ ) ).c_str() );
             host_name = host_name.substr( 0, HOST_NAME_LENGTH_LIMIT );
             std::cerr << Util::getCurrentTime() << '\t'
                       << "INFO: hostname exceeds 15 characters this can "

--- a/daemon/src/daemon.cpp
+++ b/daemon/src/daemon.cpp
@@ -281,8 +281,9 @@ int main( int argc, const char* argv[] )
     }
     else
     {
-        log_message =
-            "grpc pthread is at " + std::string( static_cast<const char*>( grpc_pthread ) );
+        std::ostringstream address_stream;
+        address_stream << grpc_pthread;
+        log_message = "grpc pthread is at " + address_stream.str();
     }
     cf_daemon.cf_logger.logger( LOG_INFO, log_message.c_str() );
 
@@ -303,8 +304,9 @@ int main( int argc, const char* argv[] )
     }
     else
     {
-        log_message = "krb refresh pthread is at " +
-                      std::string( static_cast<const char*>( krb_refresh_pthread ) );
+        std::ostringstream address_stream;
+        address_stream << krb_refresh_pthread;
+        log_message = "krb refresh pthread is at " + address_stream.str();
     }
     cf_daemon.cf_logger.logger( LOG_INFO, log_message.c_str() );
 

--- a/daemon/src/daemon.cpp
+++ b/daemon/src/daemon.cpp
@@ -1,10 +1,10 @@
 #include "daemon.h"
+#include "util.hpp"
+#include <chrono>
 #include <iostream>
 #include <libgen.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <chrono>
-#include "util.hpp"
 
 Daemon cf_daemon;
 
@@ -19,7 +19,7 @@ static const char* grpc_thread_name = "grpc_thread";
 
 static void systemd_shutdown_signal_catcher( int signo )
 {
-    printf("Credentials-fetcher shutdown: Caught signo %d\n", signo);
+    printf( "Credentials-fetcher shutdown: Caught signo %d\n", signo );
     cf_daemon.got_systemd_shutdown_signal = 1;
 }
 
@@ -138,18 +138,20 @@ std::pair<int, void*> create_pthread( void* ( *func )(void*), const char* pthrea
     return std::make_pair( EXIT_SUCCESS, tinfo );
 }
 
-int parse_cred_file_path(const std::string& cred_file_path, std::string& cred_file, std::string& cred_file_lease_id )
+int parse_cred_file_path( const std::string& cred_file_path, std::string& cred_file,
+                          std::string& cred_file_lease_id )
 {
     size_t colon_delim_pos;
     char path_lease_delimiter = ':';
 
-    if (cred_file_path.empty())
+    if ( cred_file_path.empty() )
         return EXIT_FAILURE;
 
-    colon_delim_pos = cred_file_path.find(path_lease_delimiter);
+    colon_delim_pos = cred_file_path.find( path_lease_delimiter );
 
-    //If the : delimiter is not found, then assume the cred_file_path is just the path to cred spec file and use the default lease id
-    if (colon_delim_pos == std::string::npos)
+    // If the : delimiter is not found, then assume the cred_file_path is just the path to cred spec
+    // file and use the default lease id
+    if ( colon_delim_pos == std::string::npos )
     {
         cred_file = cred_file_path;
         cred_file_lease_id = DEFAULT_CRED_FILE_LEASE_ID;
@@ -157,8 +159,8 @@ int parse_cred_file_path(const std::string& cred_file_path, std::string& cred_fi
         return EXIT_SUCCESS;
     }
 
-    cred_file = cred_file_path.substr(0, colon_delim_pos);
-    cred_file_lease_id = cred_file_path.substr(colon_delim_pos+1);
+    cred_file = cred_file_path.substr( 0, colon_delim_pos );
+    cred_file_lease_id = cred_file_path.substr( colon_delim_pos + 1 );
 
     return EXIT_SUCCESS;
 }
@@ -183,24 +185,26 @@ int main( int argc, const char* argv[] )
 
     std::string log_msg = "Credentials-fetcher daemon has started running";
     std::cerr << log_msg << std::endl;
-    cf_daemon.cf_logger.logger( LOG_ERR, "%s", log_msg.c_str());
-    std::cerr << "on request failures check logs located at " + cf_daemon.logging_dir << std::endl;;
+    cf_daemon.cf_logger.logger( LOG_ERR, "%s", log_msg.c_str() );
+    std::cerr << "on request failures check logs located at " + cf_daemon.logging_dir << std::endl;
+    ;
 
-    if ( getenv(ENV_CF_CRED_SPEC_FILE) != NULL)
+    if ( getenv( ENV_CF_CRED_SPEC_FILE ) != NULL )
     {
-        int parseResult = parse_cred_file_path( getenv(ENV_CF_CRED_SPEC_FILE), 
-                                                cred_file,
-                                                cred_file_lease_id);
+        int parseResult =
+            parse_cred_file_path( getenv( ENV_CF_CRED_SPEC_FILE ), cred_file, cred_file_lease_id );
 
-        if (parseResult == EXIT_FAILURE)
+        if ( parseResult == EXIT_FAILURE )
         {
-            std::cerr << "Failed parsing environment variable " << getenv(ENV_CF_CRED_SPEC_FILE) << std::endl;
-            cf_daemon.cf_logger.logger( LOG_ERR, "Failed parsing environment variable %s", getenv(ENV_CF_CRED_SPEC_FILE) );
+            std::cerr << "Failed parsing environment variable " << getenv( ENV_CF_CRED_SPEC_FILE )
+                      << std::endl;
+            cf_daemon.cf_logger.logger( LOG_ERR, "Failed parsing environment variable %s",
+                                        getenv( ENV_CF_CRED_SPEC_FILE ) );
 
-            exit( EXIT_FAILURE);
+            exit( EXIT_FAILURE );
         }
 
-        if (!std::filesystem::exists( cred_file))
+        if ( !std::filesystem::exists( cred_file ) )
         {
             cred_file_lease_id.clear();
             std::cerr << "Ignoring CF_CREF_FILE, file " << cred_file << " not found" << std::endl;
@@ -219,24 +223,22 @@ int main( int argc, const char* argv[] )
     cf_daemon.gmsa_account_name = CF_TEST_GMSA_ACCOUNT;
 
     std::cerr << "krb_files_dir = " << cf_daemon.krb_files_dir << std::endl;
-    //std::cerr << "cred_file = " << cf_daemon.cred_file <<  " (lease id: " << cred_file_lease_id
-             //   << ")" << std::endl;
+    // std::cerr << "cred_file = " << cf_daemon.cred_file <<  " (lease id: " << cred_file_lease_id
+    //    << ")" << std::endl;
     std::cerr << "logging_dir = " << cf_daemon.logging_dir << std::endl;
     std::cerr << "unix_socket_dir = " << cf_daemon.unix_socket_dir << std::endl;
 
     if ( cf_daemon.run_diagnostic )
     {
-        exit(  read_meta_data_json_test() ||
-              read_meta_data_invalid_json_test() || renewal_failure_krb_dir_not_found_test() ||
-              write_meta_data_json_test() );
+        exit( read_meta_data_json_test() || read_meta_data_invalid_json_test() ||
+              renewal_failure_krb_dir_not_found_test() || write_meta_data_json_test() );
     }
 
     struct sigaction sa;
     cf_daemon.got_systemd_shutdown_signal = 0;
     memset( &sa, 0, sizeof( struct sigaction ) );
     sa.sa_handler = &systemd_shutdown_signal_catcher;
-    if ( ( sigaction( SIGTERM, &sa, NULL ) == -1 ) ||
-         ( sigaction( SIGINT, &sa, NULL ) == -1 ) ||
+    if ( ( sigaction( SIGTERM, &sa, NULL ) == -1 ) || ( sigaction( SIGINT, &sa, NULL ) == -1 ) ||
          ( sigaction( SIGHUP, &sa, NULL ) == -1 ) )
     {
         perror( "sigaction" );
@@ -248,27 +250,33 @@ int main( int argc, const char* argv[] )
     // 2. grpc server
     // 3. timer to run every 45 min
 
-    if ( !cf_daemon.cred_file.empty() ) {
-        cf_daemon.cf_logger.logger( LOG_INFO, "Credential file exists %s", cf_daemon.cred_file.c_str() );
-        
-        int specFileReturn = ProcessCredSpecFile(cf_daemon.krb_files_dir, cf_daemon.cred_file, cf_daemon.cf_logger, cred_file_lease_id);
-        if (specFileReturn == EXIT_FAILURE) {
+    if ( !cf_daemon.cred_file.empty() )
+    {
+        cf_daemon.cf_logger.logger( LOG_INFO, "Credential file exists %s",
+                                    cf_daemon.cred_file.c_str() );
+
+        int specFileReturn = ProcessCredSpecFile( cf_daemon.krb_files_dir, cf_daemon.cred_file,
+                                                  cf_daemon.cf_logger, cred_file_lease_id );
+        if ( specFileReturn == EXIT_FAILURE )
+        {
             std::cerr << "ProcessCredSpecFile() non 0 " << std::endl;
             exit( EXIT_FAILURE );
         }
     }
-    
+
     /* Create one pthread for gRPC processing */
-    pthread_status =
-        create_pthread( grpc_thread_start, grpc_thread_name, -1 );
+    pthread_status = create_pthread( grpc_thread_start, grpc_thread_name, -1 );
     if ( pthread_status.first < 0 )
     {
         cf_daemon.cf_logger.logger( LOG_ERR, "Error %d: Cannot create pthreads",
-                                    pthread_status.first );
+                                    std::to_string( pthread_status.first ).c_str() );
         exit( EXIT_FAILURE );
     }
     grpc_pthread = pthread_status.second;
-    cf_daemon.cf_logger.logger( LOG_INFO, "grpc pthread is at %p", grpc_pthread );
+    cf_daemon.cf_logger.logger( LOG_INFO, "grpc pthread is at %p",
+                                grpc_pthread == nullptr
+                                    ? "Warning: grpc_pthread is null"
+                                    : static_cast<const char*>( grpc_pthread ) );
 
     /* Create pthread for refreshing krb tickets */
     pthread_status =
@@ -276,11 +284,14 @@ int main( int argc, const char* argv[] )
     if ( pthread_status.first < 0 )
     {
         cf_daemon.cf_logger.logger( LOG_ERR, "Error %d: Cannot create pthreads",
-                                    pthread_status.first );
+                                    std::to_string( pthread_status.first ).c_str() );
         exit( EXIT_FAILURE );
     }
     krb_refresh_pthread = pthread_status.second;
-    cf_daemon.cf_logger.logger( LOG_INFO, "krb refresh pthread is at %p", krb_refresh_pthread );
+    cf_daemon.cf_logger.logger( LOG_INFO, "krb refresh pthread is at %p",
+                                grpc_pthread == nullptr
+                                    ? "Warning: krb_refresh_pthread is null"
+                                    : static_cast<const char*>( krb_refresh_pthread ) );
 
     cf_daemon.cf_logger.set_log_level( LOG_NOTICE );
 
@@ -328,17 +339,16 @@ int main( int argc, const char* argv[] )
                     i ); // TBD: Remove later, visible in systemctl status
         ++i;
 #ifdef EXIT_USING_FILE
-       struct stat st;
-       if ( lstat( "/tmp/credentials_fetcher_exit.txt", &st ) != -1 )
-       {
-          if (S_ISREG(st.st_mode))
-          {
-             cf_daemon.got_systemd_shutdown_signal = 1;
-          }
-       }
+        struct stat st;
+        if ( lstat( "/tmp/credentials_fetcher_exit.txt", &st ) != -1 )
+        {
+            if ( S_ISREG( st.st_mode ) )
+            {
+                cf_daemon.got_systemd_shutdown_signal = 1;
+            }
+        }
 #endif
     }
 
     return EXIT_SUCCESS;
 }
-

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -47,6 +47,7 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
             {
                 std::list<krb_ticket_info_t*> krb_ticket_info_list =
                     read_meta_data_json( file_path );
+                std::string log_message;
 
                 // refresh the kerberos tickets for the service accounts, if tickets ready for
                 // renewal
@@ -69,9 +70,9 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
                             if ( gmsa_ticket_result.first != 0 )
                             {
                                 std::pair<int, std::string> status;
-                                cf_logger.logger(
-                                    LOG_ERR, "ERROR: Cannot get gMSA krb ticket using account %s",
-                                    krb_ticket->service_account_name.c_str() );
+                                log_message = "ERROR: Cannot get gMSA krb ticket using account " +
+                                              krb_ticket->service_account_name;
+                                cf_logger.logger( LOG_ERR, log_message.c_str() );
                                 if ( domainless_user.find( "awsdomainlessusersecret" ) !=
                                      std::string::npos )
                                 {
@@ -87,10 +88,9 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
                                 }
                                 if ( status.first < 0 )
                                 {
-                                    cf_logger.logger(
-                                        LOG_ERR, "Error %d: Cannot get machine krb ticket",
-                                        ( std::to_string( status.first ) + " " + status.second )
-                                            .c_str() );
+                                    log_message = "Error " + std::to_string( status.first ) +
+                                                  ": Cannot get machine krb ticket";
+                                    cf_logger.logger( LOG_ERR, log_message.c_str() );
                                 }
                                 else
                                 {
@@ -101,7 +101,8 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
                     }
                     else
                     {
-                        cf_logger.logger( LOG_INFO, "gMSA ticket is at %s", krb_cc_name.c_str() );
+                        log_message = "gMSA ticket is at " + krb_cc_name;
+                        cf_logger.logger( LOG_INFO, log_message.c_str() );
                     }
                 }
             }
@@ -109,11 +110,11 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
         catch ( const std::exception& ex )
         {
             std::string log_str = Util::getCurrentTime() + '\t' + "ERROR: '" + ex.what() + "'!\n";
-            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
+            cf_logger.logger( LOG_ERR, log_str.c_str() );
             std::cerr << log_str << std::endl;
             log_str = Util::getCurrentTime() + '\t' + "ERROR: failed to run ticket renewal";
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
+            cf_logger.logger( LOG_ERR, log_str.c_str() );
             break;
         }
     }

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -87,9 +87,10 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
                                 }
                                 if ( status.first < 0 )
                                 {
-                                    cf_logger.logger( LOG_ERR,
-                                                      "Error %d: Cannot get machine krb ticket",
-                                                      status );
+                                    cf_logger.logger(
+                                        LOG_ERR, "Error %d: Cannot get machine krb ticket",
+                                        ( std::to_string( status.first ) + " " + status.second )
+                                            .c_str() );
                                 }
                                 else
                                 {
@@ -108,11 +109,11 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
         catch ( const std::exception& ex )
         {
             std::string log_str = Util::getCurrentTime() + '\t' + "ERROR: '" + ex.what() + "'!\n";
-            cf_logger.logger( LOG_ERR, log_str.c_str() );
+            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
             std::cerr << log_str << std::endl;
             log_str = Util::getCurrentTime() + '\t' + "ERROR: failed to run ticket renewal";
             std::cerr << log_str << std::endl;
-            cf_logger.logger( LOG_ERR, log_str.c_str() );
+            cf_logger.logger( LOG_ERR, log_str.c_str(), "" );
             break;
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
[Opensource Ubuntu mode]
1. Remove all invocations of variadic methods using variadic params
2. Fix the logger function that used the variadic param to use a const char*
3. Remove the usage of format string from logging
4. Update logger method invokes to create C++ style string and pass as a param directly to the logger method

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

1. Logs viewed on the console:
```
Credentials-fetcher daemon has started running
on request failures check logs located at /var/credentials-fetcher/logging
krb_files_dir = /var/credentials-fetcher/krbdir
logging_dir = /var/credentials-fetcher/logging
unix_socket_dir = /var/credentials-fetcher/socket
Thread 0: top of stack near 0x7f6cb51ffbe0; argv_string=grpc_thread
Thread 0: top of stack near 0x7f6cafb7fb28; argv_string=krb_ticket_refresh_thread
2024-11-20 19:24:51     INFO: Server listening on unix:/var/credentials-fetcher/socket/credentials_fetcher.sock
2024-11-20 19:24:51     INFO: CallDataCreateKerberosLease 0x7f6cb000d770status: 0
2024-11-20 19:24:51     INFO: AddNonDomainJoinedKerberosLease 0x7f6cb000e1a0status: 0
2024-11-20 19:24:51     INFO: RenewNonDomainJoinedKerberosLease 0x7f6cb000ebe0status: 0
2024-11-20 19:24:51     INFO: CallDataDeleteKerberosLease 0x7f6cb000f600status: 0
2024-11-20 19:24:51     INFO: CallDataHealthCheck 0x7f6cb0010090 status: 0
```
2. Logs in /var/logging/credentials-fetcher.log
```
2024-11-20 19:24:51: Credentials-fetcher daemon has started running 
2024-11-20 19:24:51: grpc pthread is at 0x58816b1a21f0 
2024-11-20 19:24:51: krb refresh pthread is at 0x58816b1a22a0 
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
