### PR TITLE
use aws owned ecr for container repo

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM public.ecr.aws/ubuntu/ubuntu:20.04 as base
 ARG TIME_ZONE
 RUN if [ -z "${TIME_ZONE}" ] ; then exit 1; fi
 

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as base
+FROM public.ecr.aws/ubuntu/ubuntu:22.04 as base
 ARG TIME_ZONE
 RUN if [ -z "${TIME_ZONE}" ] ; then exit 1; fi
 


### PR DESCRIPTION
Use AWS owned public ECR for container repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
