### PR TITLE
fix ldapsearch command

### DIFF
--- a/common/util.hpp
+++ b/common/util.hpp
@@ -606,7 +606,7 @@ class Util
 
         cmd = std::string( "ldapsearch -o ldif_wrap=no -LLL -Y GSSAPI -H ldap://" ) + fqdn;
         cmd += std::string( " -b '" ) + distinguished_name + std::string( "' " ) + search_string;
-	    cmd += std::string( " -N" );
+        cmd += std::string( " -N" );
         std::cerr << Util::getCurrentTime() << '\t' << "INFO: " << cmd << std::endl;
         std::cerr << cmd << std::endl;
 

--- a/common/util.hpp
+++ b/common/util.hpp
@@ -606,7 +606,7 @@ class Util
 
         cmd = std::string( "ldapsearch -o ldif_wrap=no -LLL -Y GSSAPI -H ldap://" ) + fqdn;
         cmd += std::string( " -b '" ) + distinguished_name + std::string( "' " ) + search_string;
-
+	    cmd += std::string( " -N" );
         std::cerr << Util::getCurrentTime() << '\t' << "INFO: " << cmd << std::endl;
         std::cerr << cmd << std::endl;
 

--- a/common/util.hpp
+++ b/common/util.hpp
@@ -603,7 +603,8 @@ class Util
     {
         std::string cmd;
         std::pair<int, std::string> ldap_search_result;
-
+        // -N: Do not use reverse DNS to canonicalize SASL host name.
+        // With this flag, ldapsearch uses the IP address directly for identification purposes, rather than trying to resolve it to a hostname.
         cmd = std::string( "ldapsearch -o ldif_wrap=no -LLL -Y GSSAPI -H ldap://" ) + fqdn;
         cmd += std::string( " -b '" ) + distinguished_name + std::string( "' " ) + search_string;
         cmd += std::string( " -N" );


### PR DESCRIPTION
*Description of changes:*
ldapsearch command on ubuntu distros works when we provide `-N` flag. A corresponding change in /etc/krb5.conf to set `rdns - false` was also made to get the `gmsa_test_client` working for ubuntu distros

```
root@ip-10-0-2-67:/home/ubuntu# cat /etc/krb5.conf 
[libdefaults]
	default_realm = CONTOSO.COM
	rdns = false
```

*Testing done:*
ran the gmsa_test_client on ubuntu with this credspec on an ubuntu instance and verified that lease was created successfully. 

```
(venv) root@ip-10-0-2-67:/home/ubuntu/credentials-fetcher/protos# python3 credentials_fetcher_client.py 
Server response: lease_id: "a8111a49d9cab0293c64"
created_kerberos_file_paths: "/var/credentials-fetcher/krbdir/a8111a49d9cab0293c64/WebApp01"
```

```
(venv) root@ip-10-0-2-67:/home/ubuntu/credentials-fetcher/protos# cat credentials_fetcher_client.py 
import grpc
import credentialsfetcher_pb2
import credentialsfetcher_pb2_grpc

def run():
    with grpc.insecure_channel('unix:///var/credentials-fetcher/socket/credentials_fetcher.sock') as channel:
        stub = credentialsfetcher_pb2_grpc.CredentialsFetcherServiceStub(channel)
        credspec_contents="{\"CmsPlugins\":[\"ActiveDirectory\"],\"DomainJoinConfig\":{\"Sid\":\"S-1-5-21-2725122404-4129967127-2630707939\",\"MachineAccountName\":\"WebApp01\",\"Guid\":\"e96e0e09-9305-462f-9e44-8a8179722897\",\"DnsTreeName\":\"contoso.com\",\"DnsName\":\"contoso.com\",\"NetBiosName\":\"contoso\"},\"ActiveDirectoryConfig\":{\"GroupManagedServiceAccounts\":[{\"Name\":\"WebApp01\",\"Scope\":\"contoso.com\"},{\"Name\":\"WebApp01\",\"Scope\":\"contoso\"}], \"HostAccountConfig\": {\"PortableCcgVersion\": \"1\",\"PluginGUID\": \"{GDMA0342-266A-4D1P-831J-20990E82944F}\",\"PluginInput\": {\"CredentialArn\": \"aws/directoryservice/contoso/gmsa\"}}}"
        contents = []
        contents += [credspec_contents]
        response = stub.AddNonDomainJoinedKerberosLease(credentialsfetcher_pb2.CreateNonDomainJoinedKerberosLeaseRequest(credspec_contents = contents, username="standarduser01", password="p@ssw0rd", domain="contoso.com"))
        print(f"Server response: {response}")

if __name__ == '__main__':
  run()
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
