### PR TITLE
Use gtest: Add initial test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,3 +238,20 @@ add_test(NAME check_help COMMAND ${CMAKE_BINARY_DIR}/credentials-fetcherd "--hel
 add_test(NAME run_self_test COMMAND ${CMAKE_BINARY_DIR}/credentials-fetcherd "--self_test")
 set_tests_properties(check_help PROPERTIES WILL_FAIL TRUE)
 set_tests_properties(run_self_test PROPERTIES WILL_FAIL FALSE)
+
+
+find_package(GTest CONFIG REQUIRED)
+set(TEST_FILES test/tester.cpp)
+add_executable(credentials-fetcher-test ${metadata} ${TEST_FILES} common)
+target_include_directories(credentials-fetcher-test
+        PUBLIC
+        common
+        ${GLIB_INCLUDE_DIR}
+        ${GLIB_CONFIG_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(credentials-fetcher-test gtest gtest_main
+        systemd
+        glib-2.0
+        jsoncpp ssl crypto
+        krb5 kadm5srv_mit kdb5 gssrpc gssapi_krb5 gssrpc k5crypto
+        com_err krb5support resolv)

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+#include "daemon.h"
+
+TEST(DaemonTest, InvalidCharacterTest) {
+    ASSERT_EQ(contains_invalid_characters("abcdef"), 0);
+}


### PR DESCRIPTION
More tests need to be added in test directory.
Code-coverage info is in the web pages in the CODE_COVERAGE directory.

Instructions:
    cmake ../ -DCODE_COVERAGE=ON
    make -j
    ./credentials-fetcher-test
    cd CMakeFiles/credentials-fetcher-test.dir/test
    ls *.gcno
    gcov tester.cpp.gcno
    lcov --capture --directory . --output-file gtest_coverage.info --ignore-errors mismatch
    genhtml gtest_coverage.info --output-directory CODE_COVERAGE

Logs:
    $ ./credentials-fetcher-test
    Running main() from /builddir/build/BUILD/googletest-release-1.11.0/googletest/src/gtest_main.cc
    [==========] Running 1 test from 1 test suite.
    [----------] Global test environment set-up.
    [----------] 1 test from DaemonTest
    [ RUN      ] DaemonTest.InvalidCharacterTest
    [       OK ] DaemonTest.InvalidCharacterTest (0 ms)
    [----------] 1 test from DaemonTest (0 ms total)

    [----------] Global test environment tear-down
    [==========] 1 test from 1 test suite ran. (0 ms total)
    [  PASSED  ] 1 test.

    $  genhtml gtest_coverage.info --output-directory CODE_COVERAGE
    Found 17 entries.
    Found common filename prefix "/usr/include/c++"
    Generating output.
    Processing file 11/bits/move.h
      lines=2 hit=0 functions=3 hit=0
    Processing file /usr/include/gtest/internal/gtest-internal.h
      lines=19 hit=17 functions=8 hit=7
    Processing file 11/bits/unique_ptr.h
      lines=18 hit=6 functions=13 hit=2
    Processing file /home/ec2-user/credentials-fetcher/test/tester.cpp
      lines=2 hit=2 functions=4 hit=4
    Processing file 11/tuple
      lines=14 hit=6 functions=20 hit=4
    Processing file 11/bits/stl_iterator_base_funcs.h
      lines=5 hit=0 functions=4 hit=0
    Processing file 11/bits/alloc_traits.h
      lines=2 hit=0 functions=1 hit=0
    Processing file 11/bits/stl_iterator_base_types.h
      lines=2 hit=0 functions=2 hit=0
    Processing file 11/bits/char_traits.h
      lines=12 hit=0 functions=3 hit=0
    Processing file /usr/include/gtest/gtest.h
      lines=17 hit=6 functions=11 hit=3
    Processing file 11/bits/basic_string.tcc
      lines=13 hit=0 functions=2 hit=0
    Processing file 11/ext/new_allocator.h
      lines=3 hit=0 functions=3 hit=0
    Processing file /usr/include/gtest/gtest-printers.h
      lines=30 hit=0 functions=16 hit=0
    Processing file 11/bits/basic_string.h
      lines=11 hit=0 functions=3 hit=0
    Processing file 11/ext/alloc_traits.h
      lines=2 hit=0 functions=1 hit=0
    Processing file /usr/include/gtest/internal/gtest-port.h
      lines=1 hit=0 functions=1 hit=0
    Processing file 11/ext/type_traits.h
      lines=2 hit=0 functions=2 hit=0
    Overall coverage rate:
      lines......: 23.9% (37 of 155 lines)
      functions......: 20.6% (20 of 97 functions)

    $ ls CODE_COVERAGE/
    11         cmd_line     gcov.css   home               index-sort-l.html  ruby.png  updown.png
    amber.png  emerald.png  glass.png  index-sort-f.html  index.html         snow.png  usr

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
