### PR TITLE
fix: typo in api/tests/CMakeLists.txt

### DIFF
--- a/api/tests/CMakeLists.txt
+++ b/api/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ add_executable(gmsa_test_client "gmsa_test_client.cpp")
 target_link_libraries(gmsa_test_client
             cf_gmsa_service_private ${_PROTOBUF_LIBPROTOBUF})
 
-add_executable(gmsa_integration_test "gmsa_integration_test.cpp")
-target_link_libraries(gmsa_integration_test
+add_executable(gmsa_api_integration_test "gmsa_api_integration_test.cpp")
+target_link_libraries(gmsa_api_integration_test
             cf_gmsa_service_private
             ${_PROTOBUF_LIBPROTOBUF}
             jsoncpp
@@ -34,6 +34,6 @@ check_pie_supported()
 if (CMAKE_C_LINK_PIE_SUPPORTED)
     set_property(TARGET gmsa_test_client
                 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-    set_property(TARGET gmsa_integration_test
+    set_property(TARGET gmsa_api_integration_test
                 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif ()

--- a/api/tests/gmsa_api_integration_test.cpp
+++ b/api/tests/gmsa_api_integration_test.cpp
@@ -175,7 +175,7 @@ TEST_F( GmsaIntegrationTest, A_AddKerberosArnLeaseMethod_Test )
     // Prepare request
     credentialsfetcher::KerberosArnLeaseRequest request;
 
-    std::string arn = get_environment_var( "CREDSPEC_ARN" );
+    std::string arn = get_environment_var( CF_TEST_CREDSPEC_ARN );
     arn += "#123/WebApp01";
     request.add_credspec_arns( arn );
     request.set_access_key_id( get_environment_var( AWS_ACCESS_KEY_ID ) );


### PR DESCRIPTION
*Description of changes:* Fix typo in API Integration test resulting in build failure
- Fixed env variable usage
- Fixed api integration test file name in CmakeList

*Testing done:*
`cmake ../ && make -j`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [na] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [na] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
