### PR TITLE
Conditionally add build dependency awscli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(credentials-fetcher VERSION 1.3.6)
+project(credentials-fetcher VERSION 1.3.71)
 
 include(GNUInstallDirs)
 
@@ -12,7 +12,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 set(CMAKE_SHARED_LINKER_FLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 
 # cmake ../ -DENABLE_DEBUGGING=ON
-option(ENABLE_DEBUGGING "Enable debugging" ON)
+option(ENABLE_DEBUGGING "Enable debugging" OFF)
 if(ENABLE_DEBUGGING)
     message("Enable debugging")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
@@ -31,6 +31,9 @@ if(CODE_COVERAGE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage -fprofile-arcs -ftest-coverage -lgcov ")
     endif()
 endif()
+
+# cmake -DBUILD_INTEGRATION_TESTS=ON
+option(BUILD_INTEGRATION_TESTS "Build integration tests" OFF)
 
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(Protobuf CONFIG)

--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ export CF_TEST_DOMAIN=XXXX
 ``` 
 
 #### Build && Test
-Follow the instructions from [Standalone mode](#standalone-mode) sections to build the code, generate binaries and start the server. Once the server has started, run integration tests by running
+Follow the instructions from [Standalone mode](#standalone-mode) sections to build the code with the integration test flag enabled, generate binaries and start the server. Once the server has started, run integration tests
 
 ```
 cd credentials-fetcher/build/
+cmake -DBUILD_INTEGRATION_TESTS=ON .. && make -j
+# Start the server from another terminal and run `sudo ./credentials-fetcherd`
 sudo -E api/tests/gmsa_api_integration_test 
 ```
 

--- a/api/tests/CMakeLists.txt
+++ b/api/tests/CMakeLists.txt
@@ -20,20 +20,24 @@ add_executable(gmsa_test_client "gmsa_test_client.cpp")
 target_link_libraries(gmsa_test_client
             cf_gmsa_service_private ${_PROTOBUF_LIBPROTOBUF})
 
-add_executable(gmsa_api_integration_test "gmsa_api_integration_test.cpp")
-target_link_libraries(gmsa_api_integration_test
-            cf_gmsa_service_private
-            ${_PROTOBUF_LIBPROTOBUF}
-            jsoncpp
-            gtest
-            gtest_main)
+if(BUILD_INTEGRATION_TESTS)
+    add_executable(gmsa_api_integration_test "gmsa_api_integration_test.cpp")
+    target_link_libraries(gmsa_api_integration_test
+                cf_gmsa_service_private
+                ${_PROTOBUF_LIBPROTOBUF}
+                jsoncpp
+                gtest
+                gtest_main)
+    if (CMAKE_C_LINK_PIE_SUPPORTED)
+        set_property(TARGET gmsa_api_integration_test
+                    PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+    endif ()
+endif ()
 
 cmake_policy(SET CMP0083 NEW)
 include(CheckPIESupported)
 check_pie_supported()
 if (CMAKE_C_LINK_PIE_SUPPORTED)
     set_property(TARGET gmsa_test_client
-                PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-    set_property(TARGET gmsa_api_integration_test
                 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif ()

--- a/package/credentials-fetcher.spec
+++ b/package/credentials-fetcher.spec
@@ -1,6 +1,6 @@
 %global major_version 1
 %global minor_version 3
-%global patch_version 7
+%global patch_version 71
  
 # For handling bump release by rpmdev-bumpspec and mass rebuild
 %global baserelease 0
@@ -12,7 +12,7 @@ Summary:        credentials-fetcher is a daemon that refreshes tickets or tokens
  
 License:        Apache-2.0
 URL:            https://github.com/aws/credentials-fetcher
-Source0:        credentials-fetcher-v.1.3.7.tar.gz
+Source0:        credentials-fetcher-v.1.3.71.tar.gz
 
 BuildRequires:  cmake3 make chrpath openldap-clients grpc-devel gcc-c++ glib2-devel jsoncpp-devel
 BuildRequires:  openssl-devel zlib-devel protobuf-devel re2-devel krb5-devel systemd-devel
@@ -20,12 +20,14 @@ BuildRequires:  systemd-rpm-macros grpc-plugins
 
 %if 0%{?amzn} >= 2023
 BuildRequires:  aws-sdk-cpp-devel aws-sdk-cpp aws-sdk-cpp-static
+%else
+BuildRequires:  awscli
 %endif
 
 BuildRequires:  dotnet-sdk-8.0
 Requires: dotnet-runtime-8.0
 
-Requires: bind-utils openldap openldap-clients awscli jsoncpp
+Requires: bind-utils openldap openldap-clients jsoncpp
 # No one likes you i686
 ExclusiveArch: x86_64 aarch64 s390x
  
@@ -70,6 +72,10 @@ ctest3
 %attr(0755, -, -) %{_sbindir}/krb5.conf
 
 %changelog
+
+* Wed Feb 12 Anushka Srinivasa <as14692@nyu.edu> - 1.3.71
+- Conditionally add build dependency awscli
+
 * Fri Jan 17 2025 Samiullah Mohammed <samiull@amazon.com> - 1.3.7
 - DNS and associated retries
 - Complex DN support


### PR DESCRIPTION
# Description of changes

1. Modified package dependencies
   - Adding awscli in build dependencies increases the credentials-fetcher image size by ~200 MB. Since Fargate has a size restriction, removing the dependency in al2023
1. Updated version from 1.3.6 to 1.3.71 in CMakeLists.txt
1. Disabled debugging by default (`ENABLE_DEBUGGING` set to OFF)
1. Added `BUILD_INTEGRATION_TESTS` option and made integration tests conditional
1. Updated README.md with clearer instructions for running integration tests



These changes appear to focus on improving build configuration and dependency management while making integration testing more flexible.

# Testing done
`cmake ../ && make -j && make install`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
