### PR TITLE
Conditional restart ecs in systemd service script

### DIFF
--- a/api/src/gmsa_service.cpp
+++ b/api/src/gmsa_service.cpp
@@ -945,6 +945,7 @@ class CredentialsFetcherImpl final
                     std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                 }
 
+                std::cout << Util::getCurrentTime() << '\t' << "INFO: CallDataRenewKerberosArnLease renewal started for " << username  << std::endl;
                 secureClearString( username );
                 secureClearString( password );
                 secureClearString( accessId );
@@ -1768,6 +1769,7 @@ class CredentialsFetcherImpl final
                     std::cerr << Util::getCurrentTime() << '\t' << err_msg << std::endl;
                 }
 
+                std::cout << Util::getCurrentTime() << '\t' << "INFO: CallDataRenewNonDomainJoinedKerberosLease renewal started for " << username  << std::endl;
                 secureClearString( username );
                 secureClearString( password );
 

--- a/renewal/src/renewal.cpp
+++ b/renewal/src/renewal.cpp
@@ -22,7 +22,6 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
         {
             auto x = std::chrono::steady_clock::now() + std::chrono::minutes( interval );
             std::this_thread::sleep_until( x );
-            std::cout << Util::getCurrentTime() << '\t' << "INFO: renewal started" << std::endl;
 
             // identify the metadata files in the krb directory
             std::vector<std::string> metadatafiles;
@@ -62,6 +61,7 @@ int krb_ticket_renew_handler( Daemon cf_daemon )
                                std::string::npos ) &&
                          is_ticket_ready_for_renewal( krb_ticket, cf_daemon.cf_logger ) )
                     {
+                        std::cout << Util::getCurrentTime() << '\t' << "INFO: renewal started for " << domainless_user << std::endl;
                         int num_retries = 1;
                         for ( int i = 0; i <= num_retries; i++ )
                         {

--- a/scripts/systemd/credentials-fetcher.service
+++ b/scripts/systemd/credentials-fetcher.service
@@ -11,6 +11,7 @@ ExecStartPre=chmod 755 /var/credentials-fetcher /var/credentials-fetcher/krbdir 
 ExecStart=/usr/sbin/credentials-fetcherd
 ExecStartPost=chgrp ec2-user /var/credentials-fetcher/socket/credentials_fetcher.sock
 ExecStartPost=chmod 660 /var/credentials-fetcher/socket/credentials_fetcher.sock
+ExecStartPost=-/bin/sh -c 'UPTIME_SECONDS=$$(awk "{print $$1}" /proc/uptime | cut -d. -f1); LOCK_FILE="/var/credentials-fetcher/ecs_restart.lock"; if [ $$UPTIME_SECONDS -le 86400 ]; then echo "System uptime is $$UPTIME_SECONDS seconds (<=1 day), skipping ECS restart"; elif [ -f "$$LOCK_FILE" ]; then echo "ECS restart lock file exists, skipping restart (remove $$LOCK_FILE to allow restart)"; else echo "System uptime is $$UPTIME_SECONDS seconds (>1 day), restarting ECS service"; systemctl restart ecs && touch "$$LOCK_FILE" && echo "ECS restarted successfully, lock file created at $$LOCK_FILE"; fi'
 Environment="CREDENTIALS_FETCHERD_STARTED_BY_SYSTEMD=1"
 Type=notify
 NotifyAccess=main


### PR DESCRIPTION
This is not for any known issue, this is for unknown 'heisenbugs'.

Added an optional script to the systemd service file of credentials-fetcher. This script gets executed during 'systemctl restart credentials-fetcher'. The restart of ecs occurs only once, the human operator has to delete the lock file to allow the next restart.

The script is optional due to the '-' at the front, so, even if it failed, it will not affect the restart of credentials-fetcher.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/credentials-fetcher/blob/mainline/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests
- Tested in ec2 instance
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
