### PR TITLE
Add dependency to ECS agent service

### DIFF
--- a/configuration/bin/ecs-require-credentials-fetcher.conf
+++ b/configuration/bin/ecs-require-credentials-fetcher.conf
@@ -1,0 +1,6 @@
+[Unit]
+BindsTo=credentials-fetcher.service
+After=credentials-fetcher.service
+
+[Service]
+ExecStartPre=/bin/bash -c 'until [ -S /var/credentials-fetcher/socket/credentials_fetcher.sock ]; do sleep 1; done'

--- a/credentials-fetcher.spec
+++ b/credentials-fetcher.spec
@@ -99,17 +99,18 @@ chmod 644 %{_unitdir}/%{SERVICE_NAME}
 /usr/bin/systemctl is-enabled --quiet ecs.service 2>/dev/null && /usr/bin/systemctl restart ecs.service || :
 
 %postun
-# If the user ran our systemd dependency script, there will be an out-of-package systemd drop-in for ECS agent.
-# Remove this, and also clean up the drop-in directory, but only if it is empty after removing ours.
-if [ -d "/usr/lib/systemd/system/ecs.service.d" ]; then
-    rm /usr/lib/systemd/system/ecs.service.d/require-credentials-fetcher.conf
-    if [ -z "$( ls -A '/usr/lib/systemd/system/ecs.service.d' )" ]; then
-        rm -rf /usr/lib/systemd/system/ecs.service.d
-    fi
-fi
 /usr/bin/systemctl daemon-reload
-# Service continues running after a full removal, so stop it
+# If this is a full removal, and *NOT* an upgrade:
 if [ $1 -eq 0 ]; then
+    # If the user ran our systemd dependency script, there will be an out-of-package systemd drop-in for ECS agent.
+    # Remove this, and also clean up the drop-in directory, but only if it is empty after removing ours.
+    if [ -d "/usr/lib/systemd/system/ecs.service.d" ]; then
+        rm /usr/lib/systemd/system/ecs.service.d/require-credentials-fetcher.conf
+        if [ -z "$( ls -A '/usr/lib/systemd/system/ecs.service.d' )" ]; then
+            rm -rf /usr/lib/systemd/system/ecs.service.d
+        fi
+    fi
+    # Service continues running after a full removal, so stop it
     /usr/bin/systemctl stop credentials-fetcher.service
 fi
 

--- a/credentials-fetcher.spec
+++ b/credentials-fetcher.spec
@@ -7,7 +7,7 @@
 
 Name: credentials-fetcher
 Version: %{major_version}.%{minor_version}.%{patch_version}
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: Apache 2.0
 Summary: Credentials Fetcher Service is used to connect to Active Directory from Linux Instances
 URL: https://github.com/aws/credentials-fetcher
@@ -117,3 +117,8 @@ fi
 %changelog
 * Wed Jan 28 2026 Muskan Lalit 2.0.0 <muskanl@amazon.com >-
 - credentials-fetcher Golang Release
+
+* Fri Feb 13 2026 Wayne Galen 2.0.0-2 <lewayne@amazon.com >-
+- Add startup ordering fixup script, to be called from userdata
+- New `/docs` directory, to be populated further later
+- Fix minor issue where service stays running after an uninstall

--- a/credentials-fetcher.spec
+++ b/credentials-fetcher.spec
@@ -5,33 +5,33 @@
 %global minor_version 0
 %global patch_version 0
 
-Name:           credentials-fetcher
-Version:        %{major_version}.%{minor_version}.%{patch_version}
-Release:        1%{?dist}
-License:        Apache 2.0
-Summary:        Credentials Fetcher Service is used to connect to Active Directory from Linux Instances
-URL:            https://github.com/aws/credentials-fetcher
-Source:         %{name}-%{version}-src.tar.gz
+Name: credentials-fetcher
+Version: %{major_version}.%{minor_version}.%{patch_version}
+Release: 1%{?dist}
+License: Apache 2.0
+Summary: Credentials Fetcher Service is used to connect to Active Directory from Linux Instances
+URL: https://github.com/aws/credentials-fetcher
+Source: %{name}-%{version}-src.tar.gz
 
 # Runtime requirements
-Requires:       openldap-clients
-Requires:       krb5-workstation
-Requires:       sssd
+Requires: openldap-clients
+Requires: krb5-workstation
+Requires: sssd
 
 # Build requirements for Go compilation
-BuildRequires:  make
-BuildRequires:  krb5-devel
+BuildRequires: make
+BuildRequires: krb5-devel
 
 # Conditional dependencies based on OS version
 %if 0%{?is_al2023}
-BuildRequires:  glibc-devel
+BuildRequires: glibc-devel
 %else
-BuildRequires:  glibc-static
+BuildRequires: glibc-static
 %endif
 
 # Required for systemd macros
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?is_al2023}
-BuildRequires:  systemd-rpm-macros
+BuildRequires: systemd-rpm-macros
 %endif
 
 # Define _unitdir if not already defined
@@ -59,13 +59,14 @@ rm -rf ${RPM_BUILD_ROOT}
 
 # Create directory structure in buildroot
 mkdir -p %{buildroot}/usr/sbin
-mkdir -p %{buildroot}%{_unitdir}
+mkdir -p %{buildroot}%{_unitdir}/ecs.service.d
 mkdir -p %{buildroot}/var/credentials-fetcher/{krbdir,socket,logging}
 mkdir -p %{buildroot}/etc/
 
 # Copy binary and service file to buildroot
 cp ./opensource/bin/credentials-fetcherd %{buildroot}/usr/sbin/credentials-fetcher
 cp ./configuration/bin/credentials-fetcher.service %{buildroot}%{_unitdir}/
+cp ./configuration/bin/ecs-require-credentials-fetcher.conf %{buildroot}%{_unitdir}/ecs.service.d/
 
 # Copy config file to buildroot
 cp ./configuration/conf/credentials-fetcher.conf %{buildroot}/etc/
@@ -77,6 +78,7 @@ rm -rf ${RPM_BUILD_ROOT}
 /usr/sbin/credentials-fetcher
 /etc/credentials-fetcher.conf
 %{_unitdir}/credentials-fetcher.service
+%{_unitdir}/ecs.service.d/ecs-require-credentials-fetcher.conf
 %dir /var/credentials-fetcher
 %dir /var/credentials-fetcher/krbdir
 %dir /var/credentials-fetcher/socket
@@ -85,10 +87,17 @@ rm -rf ${RPM_BUILD_ROOT}
 %post
 chmod 644 %{_unitdir}/%{SERVICE_NAME}
 /usr/bin/systemctl daemon-reload
+# Since `ecs.service` gets a new dependency on `credentials-fetcher.service`, it stops on the initial reload. Start it back up if enabled
+/usr/bin/systemctl is-enabled --quiet ecs.service 2>/dev/null && /usr/bin/systemctl restart ecs.service || :
 
 %postun
 /usr/bin/systemctl daemon-reload
+# Service continues running after a full removal, so stop it, and ensure ecs is still up if enabled
+if [ $1 -eq 0 ]; then
+    /usr/bin/systemctl stop credentials-fetcher.service
+    /usr/bin/systemctl is-enabled --quiet ecs.service 2>/dev/null && /usr/bin/systemctl restart ecs.service || :
+fi
 
 %changelog
-* Wed Jan 28 2026 Muskan Lalit <muskanl@amazon.com> - 2.0.0
-- credentials-fetcher Golang Release 
+* Wed Jan 28 2026 Muskan Lalit 2.0.0 <muskanl@amazon.com >-
+- credentials-fetcher Golang Release

--- a/credentials-fetcher.spec
+++ b/credentials-fetcher.spec
@@ -37,6 +37,9 @@ BuildRequires: systemd-rpm-macros
 # Define _unitdir if not already defined
 %{!?_unitdir: %global _unitdir /usr/lib/systemd/system}
 
+# Define _libexec if not already defined
+${!?_libexec: %global _libexec /usr/libexec}
+
 # Following are needed to prevent RPM build errors
 %define _missing_build_ids_terminate_build 0
 %define debug_package %{nil}
@@ -62,11 +65,15 @@ mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}%{_unitdir}/ecs.service.d
 mkdir -p %{buildroot}/var/credentials-fetcher/{krbdir,socket,logging}
 mkdir -p %{buildroot}/etc/
+mkdir -p %{buildroot}%{_libexec}
 
 # Copy binary and service file to buildroot
 cp ./opensource/bin/credentials-fetcherd %{buildroot}/usr/sbin/credentials-fetcher
 cp ./configuration/bin/credentials-fetcher.service %{buildroot}%{_unitdir}/
 cp ./configuration/bin/ecs-require-credentials-fetcher.conf %{buildroot}%{_unitdir}/ecs.service.d/
+
+# Copy startup-order userdata script into libexec
+cp ./scripts/credentials-fetcher-startup-order.sh %{buildroot}%{_libexec}/
 
 # Copy config file to buildroot
 cp ./configuration/conf/credentials-fetcher.conf %{buildroot}/etc/
@@ -83,6 +90,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %dir /var/credentials-fetcher/krbdir
 %dir /var/credentials-fetcher/socket
 %dir /var/credentials-fetcher/logging
+%{_libexec}/credentials-fetcher-startup-order.sh
 
 %post
 chmod 644 %{_unitdir}/%{SERVICE_NAME}
@@ -91,11 +99,18 @@ chmod 644 %{_unitdir}/%{SERVICE_NAME}
 /usr/bin/systemctl is-enabled --quiet ecs.service 2>/dev/null && /usr/bin/systemctl restart ecs.service || :
 
 %postun
+# If the user ran our systemd dependency script, there will be an out-of-package systemd drop-in for ECS agent.
+# Remove this, and also clean up the drop-in directory, but only if it is empty after removing ours.
+if [ -d "/usr/lib/systemd/system/ecs.service.d" ]; then
+    rm /usr/lib/systemd/system/ecs.service.d/require-credentials-fetcher.conf
+    if [ -z "$( ls -A '/usr/lib/systemd/system/ecs.service.d' )" ]; then
+        rm -rf /usr/lib/systemd/system/ecs.service.d
+    fi
+fi
 /usr/bin/systemctl daemon-reload
-# Service continues running after a full removal, so stop it, and ensure ecs is still up if enabled
+# Service continues running after a full removal, so stop it
 if [ $1 -eq 0 ]; then
     /usr/bin/systemctl stop credentials-fetcher.service
-    /usr/bin/systemctl is-enabled --quiet ecs.service 2>/dev/null && /usr/bin/systemctl restart ecs.service || :
 fi
 
 %changelog

--- a/docs/userdata.md
+++ b/docs/userdata.md
@@ -1,0 +1,25 @@
+# Configuring userdata for credentials-fetcher
+
+Currently, there is a known issue where the startup order between `ecs.service` and `credentials-fetcher.service` matters. If `ecs.service` starts before `credentials-fetcher.service`, then gMSA tasks will fail to start due to a socket error.
+
+If we ensure that `credentials-fetcher.service` starts first, then the socket will work when the ECS agent tries to use it.
+
+To do this, we ship a script that will place a drop-in file for `ecs.service`, which forces the `ecs.service` unit to consider `credentials-fetcher.service` as a dependency, and is intended to be called from your userdata script during startup, after installing the `credentials-fetcher` package.
+
+You can call this from your userdata as follows:
+```
+/usr/libexec/credentials-fetcher-startup-order.sh
+```
+
+After running this script, any time ~ecs.service~ is started in the future, ~credentials-fetcher.service~ is guaranteed to start first.
+
+# Removing the dependency
+
+If you wish to no longer have this dependency relationship in place, you can simply remove the drop-in file:
+```
+rm /usr/lib/systemd/system/ecs.service.d/require-credentials-fetcher.conf
+
+if [ -z "$( ls -A '/usr/lib/systemd/system/ecs.service.d' )" ]; then
+    rm -rf /usr/lib/systemd/system/ecs.service.d
+fi
+```

--- a/scripts/credentials-fetcher-startup-order.sh
+++ b/scripts/credentials-fetcher-startup-order.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+# Forces `ecs.service` to depend on `credentials-fetcher.service`
+#
+# This works around known issues where gMSA tasks fail to start if the ECS agent
+# starts before credentials-fetcher,
+#
+# This script is intended to be run as part of the instance userdata script
+
+echo "Creating drop-in file for ecs.service..."
+mkdir /usr/lib/systemd/system/ecs.service.d
+cat > /usr/lib/systemd/system/ecs.service.d/require-credentials-fetcher.conf <<EOF
+[Unit]
+Wants=credentials-fetcher.service
+After=credentials-fetcher.service
+
+[Service]
+ExecStartPre=/bin/bash -c 'until [ -S /var/credentials-fetcher/socket/credentials_fetcher.sock ]; do sleep 1; done'
+EOF
+echo "Done! The ECS agent service will now start credentials-fetcher as a requirement. Restarting ECS agent if already running."
+systemctl daemon-reload
+systemctl is-active --quiet ecs.service 2>/dev/null && systemctl restart ecs.service || :


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
If ECS starts before credentials-fetcher, the agent fails to connect to the credentials-fetcher socket. So, when installing `credentials-fetcher.service`, add a drop-in configuration for `ecs.service`, so that `credentials-fetcher.service` effectively becomes a component of `ecs.service`.

With this change, if `ecs.service` is started, stopped, or restarted, `credentials-fetcher.service` will also do the same, and `ecs.service` will wait for the socket file to be created when starting `credentials-fetcher.service`.

Since `ecs.service` becomes so tightly coupled with `credentials-fetcher.service`, we don't have to explicitly enable it for it to start on systems where the ECS agent is installed. Instead, `ecs.service` triggers the service to start with it as a dependency.

If this is installed on a system where ECS agent is not installed, there are no side effects. Although there would be a drop-in file for `ecs.service`, without the underlying unit file also present (provided by ECS agent), the drop-in will be ignored by systemd. Similarly, this approach does not clobber any of the files provided by ECS agent directly, and simply leverages existing systemd functionality to enforce our intent and requirement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
