### PR TITLE
fix: correct NetBiosName casing in CredSpec parser

### DIFF
--- a/internal/utils/grpc_utils/grpc_utils.go
+++ b/internal/utils/grpc_utils/grpc_utils.go
@@ -131,7 +131,7 @@ func extractDomainInfo(root map[string]interface{}) (domainName string, netbiosN
 		return "", "", fmt.Errorf("missing or invalid DnsName in credential spec")
 	}
 
-	if netbios, ok := domainJoinConfig["NetbiosName"].(string); ok {
+	if netbios, ok := domainJoinConfig["NetBiosName"].(string); ok {
 		netbiosName = netbios
 	}
 


### PR DESCRIPTION
The DomainJoinConfig key is "NetBiosName" (capital B) per the Microsoft CredSpec format, but the code was looking for "NetbiosName" (lowercase b). Since Go map lookups are case-sensitive, the NetBIOS name was never extracted.

Fixes #228
