### PR TITLE
fix: correct NetBiosName casing in CredSpec parser

### DIFF
--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -108,7 +108,7 @@ func TestCredentialsFetcherServer_AddKerberosLease(t *testing.T) {
 
 	// Test AddKerberosLease
 	req := &pb.CreateKerberosLeaseRequest{
-		CredspecContents: []string{`{"DomainJoinConfig":{"DnsName":"example.com","MachineAccountName":"testmachine","Sid":"S-1-5-21-1234567890-1234567890-1234567890","DnsTreeName":"example.com","Guid":"12345678-1234-1234-1234-123456789012","NetbiosName":"EXAMPLE"},"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"testaccount","Scope":"example.com"}]},"HostAccountConfig":{"PluginInput":{"CredentialArn":"arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret"}}}`},
+		CredspecContents: []string{`{"DomainJoinConfig":{"DnsName":"example.com","MachineAccountName":"testmachine","Sid":"S-1-5-21-1234567890-1234567890-1234567890","DnsTreeName":"example.com","Guid":"12345678-1234-1234-1234-123456789012","NetBiosName":"EXAMPLE"},"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"testaccount","Scope":"example.com"}]},"HostAccountConfig":{"PluginInput":{"CredentialArn":"arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret"}}}`},
 	}
 	resp, err := client.AddKerberosLease(context.Background(), req)
 

--- a/internal/utils/grpc_utils/grpc_utils.go
+++ b/internal/utils/grpc_utils/grpc_utils.go
@@ -131,7 +131,7 @@ func extractDomainInfo(root map[string]interface{}) (domainName string, netbiosN
 		return "", "", fmt.Errorf("missing or invalid DnsName in credential spec")
 	}
 
-	if netbios, ok := domainJoinConfig["NetbiosName"].(string); ok {
+	if netbios, ok := domainJoinConfig["NetBiosName"].(string); ok {
 		netbiosName = netbios
 	}
 

--- a/internal/utils/grpc_utils/grpc_utils_test.go
+++ b/internal/utils/grpc_utils/grpc_utils_test.go
@@ -36,7 +36,7 @@ func TestParseCredSpec(t *testing.T) {
 	validCredSpec := `{
 		"DomainJoinConfig": {
 			"DnsName": "example.com",
-			"NetbiosName": "EXAMPLE"
+			"NetBiosName": "EXAMPLE"
 		},
 		"ActiveDirectoryConfig": {
 			"GroupManagedServiceAccounts": [
@@ -100,7 +100,7 @@ func TestParseCredSpec(t *testing.T) {
 	t.Run("Missing DnsName", func(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -120,7 +120,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			}
 		}`
 		_, err := ParseCredSpec(badCredSpec)
@@ -132,7 +132,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {}
 		}`
@@ -145,7 +145,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": []
@@ -160,7 +160,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -179,7 +179,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "invalid_domain",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -199,7 +199,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -219,7 +219,7 @@ func TestParseCredSpec(t *testing.T) {
 		domainJoinedCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -241,7 +241,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [
@@ -262,7 +262,7 @@ func TestParseCredSpec(t *testing.T) {
 		badCredSpec := `{
 			"DomainJoinConfig": {
 				"DnsName": "example.com",
-				"NetbiosName": "EXAMPLE"
+				"NetBiosName": "EXAMPLE"
 			},
 			"ActiveDirectoryConfig": {
 				"GroupManagedServiceAccounts": [

--- a/internal/utils/krb_utils/krb_utils_test.go
+++ b/internal/utils/krb_utils/krb_utils_test.go
@@ -520,7 +520,7 @@ func TestProcessCredentialSpecs(t *testing.T) {
 				`{
 					"DomainJoinConfig": {
 						"DnsName": "example.com",
-						"NetbiosName": "EXAMPLE"
+						"NetBiosName": "EXAMPLE"
 					},
 					"ActiveDirectoryConfig": {
 						"GroupManagedServiceAccounts": [
@@ -534,7 +534,7 @@ func TestProcessCredentialSpecs(t *testing.T) {
 				`{
 					"DomainJoinConfig": {
 						"DnsName": "example.com",
-						"NetbiosName": "EXAMPLE"
+						"NetBiosName": "EXAMPLE"
 					},
 					"ActiveDirectoryConfig": {
 						"GroupManagedServiceAccounts": [
@@ -558,7 +558,7 @@ func TestProcessCredentialSpecs(t *testing.T) {
 				`{
 					"DomainJoinConfig": {
 						"DnsName": "example.com",
-						"NetbiosName": "EXAMPLE"
+						"NetBiosName": "EXAMPLE"
 					},
 					"ActiveDirectoryConfig": {
 						"GroupManagedServiceAccounts": [
@@ -587,7 +587,7 @@ func TestProcessCredentialSpecs(t *testing.T) {
 				`{
 					"DomainJoinConfig": {
 						"DnsName": "example.com",
-						"NetbiosName": "EXAMPLE"
+						"NetBiosName": "EXAMPLE"
 					},
 					"ActiveDirectoryConfig": {
 						"GroupManagedServiceAccounts": [
@@ -601,7 +601,7 @@ func TestProcessCredentialSpecs(t *testing.T) {
 				`{
 					"DomainJoinConfig": {
 						"DnsName": "example.com",
-						"NetbiosName": "EXAMPLE"
+						"NetBiosName": "EXAMPLE"
 					},
 					"ActiveDirectoryConfig": {
 						"GroupManagedServiceAccounts": [


### PR DESCRIPTION
The DomainJoinConfig key is "NetBiosName" (capital B) per the Microsoft CredSpec format, but the code was looking for "NetbiosName" (lowercase b). Since Go map lookups are case-sensitive, the NetBIOS name was never extracted.

Fixes #228